### PR TITLE
Cleanup ifdefs and revise hashing algorithm

### DIFF
--- a/QRCoder.Xaml/XamlQRCode.cs
+++ b/QRCoder.Xaml/XamlQRCode.cs
@@ -1,5 +1,4 @@
-﻿#if NETFRAMEWORK || NET5_0_WINDOWS || NET6_0_WINDOWS
-using System;
+﻿using System;
 using System.Windows;
 using System.Windows.Media;
 using static QRCoder.QRCodeGenerator;
@@ -93,5 +92,3 @@ namespace QRCoder.Xaml
         }
     }
 }
-
-#endif

--- a/QRCoder/ArtQRCode.cs
+++ b/QRCoder/ArtQRCode.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING
 
 using System;
 using System.Drawing;
@@ -9,7 +9,7 @@ using static QRCoder.QRCodeGenerator;
 // pull request raised to extend library used. 
 namespace QRCoder
 {
-#if NET6_0_WINDOWS
+#if NET6_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     public class ArtQRCode : AbstractQRCode, IDisposable
@@ -258,7 +258,7 @@ namespace QRCoder
         }
     }
 
-#if NET6_0_WINDOWS
+#if NET6_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     public static class ArtQRCodeHelper

--- a/QRCoder/Base64QRCode.cs
+++ b/QRCoder/Base64QRCode.cs
@@ -62,7 +62,7 @@ namespace QRCoder
                 return Convert.ToBase64String(pngData, Base64FormattingOptions.None);
             }
 
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING
 #pragma warning disable CA1416 // Validate platform compatibility
             var qr = new QRCode(QrCodeData);
             var base64 = string.Empty;
@@ -77,7 +77,7 @@ namespace QRCoder
 #endif
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING
 #if NET6_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
@@ -93,7 +93,7 @@ namespace QRCoder
         }
 #endif
 
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING
 #if NET6_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -2516,14 +2516,10 @@ namespace QRCoder
                 var cp = characterSet.ToString().Replace("_", "-");
                 var bytes = ToBytes();
 
-#if !NET35_OR_GREATER && !NETSTANDARD1_3_OR_GREATER
+#if NETCOREAPP
                 System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
 #endif
-#if NETSTANDARD1_3              
-                return Encoding.GetEncoding(cp).GetString(bytes,0,bytes.Length);
-#else
-                return Encoding.GetEncoding(cp).GetString(bytes);
-#endif
+                return Encoding.GetEncoding(cp).GetString(bytes, 0, bytes.Length);
             }
 
             /// <summary>
@@ -2536,7 +2532,7 @@ namespace QRCoder
             {
                 //Setup byte encoder
                 //Encode return string as byte[] with correct CharacterSet
-#if !NET35_OR_GREATER
+#if !NETFRAMEWORK   // -- why different ifdef than line 2519? --
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
                 var cp = this.characterSet.ToString().Replace("_", "-");

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -2516,8 +2516,8 @@ namespace QRCoder
                 var cp = characterSet.ToString().Replace("_", "-");
                 var bytes = ToBytes();
 
-#if NETCOREAPP
-                System.Text.Encoding.RegisterProvider(System.Text.CodePagesEncodingProvider.Instance);
+#if !NETFRAMEWORK
+                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
                 return Encoding.GetEncoding(cp).GetString(bytes, 0, bytes.Length);
             }
@@ -2532,7 +2532,7 @@ namespace QRCoder
             {
                 //Setup byte encoder
                 //Encode return string as byte[] with correct CharacterSet
-#if !NETFRAMEWORK   // -- why different ifdef than line 2519? --
+#if !NETFRAMEWORK
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 #endif
                 var cp = this.characterSet.ToString().Replace("_", "-");
@@ -3111,7 +3111,7 @@ namespace QRCoder
             Encoding utf8 = Encoding.UTF8;
             byte[] utfBytes = utf8.GetBytes(message);
             byte[] isoBytes = Encoding.Convert(utf8, iso, utfBytes);
-            return iso.GetString(isoBytes, 0, isoBytes.Length);
+            return iso.GetString(isoBytes);
         }
 
         private static string EscapeInput(string inp, bool simple = false)

--- a/QRCoder/PdfByteQRCode.cs
+++ b/QRCoder/PdfByteQRCode.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+﻿#if SYSTEM_DRAWING
 using System;
 using System.Collections.Generic;
 using System.Drawing.Imaging;
@@ -11,7 +11,7 @@ using static QRCoder.QRCodeGenerator;
 namespace QRCoder
 {
 
-#if NET6_0_WINDOWS
+#if NET6_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     // ReSharper disable once InconsistentNaming
@@ -213,7 +213,7 @@ namespace QRCoder
         }
     }
 
-#if NET6_0_WINDOWS
+#if NET6_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     public static class PdfByteQRCodeHelper

--- a/QRCoder/QRCode.cs
+++ b/QRCoder/QRCode.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING
 using System;
 using System.Drawing;
 using System.Drawing.Drawing2D;
@@ -6,7 +6,7 @@ using static QRCoder.QRCodeGenerator;
 
 namespace QRCoder
 {
-#if NET6_0_WINDOWS
+#if NET6_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     public class QRCode : AbstractQRCode, IDisposable
@@ -128,7 +128,7 @@ namespace QRCoder
         }
     }
 
-#if NET6_0_WINDOWS
+#if NET6_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
     public static class QRCodeHelper

--- a/QRCoder/QRCodeData.cs
+++ b/QRCoder/QRCodeData.cs
@@ -22,7 +22,6 @@ namespace QRCoder
                 this.ModuleMatrix.Add(new BitArray(size));
         }
 
-        [Obsolete("This constructor will be removed in version 2.0.0.")]
         public QRCodeData(string pathToRawData, Compression compressMode) : this(File.ReadAllBytes(pathToRawData), compressMode)
         {
         }

--- a/QRCoder/QRCodeData.cs
+++ b/QRCoder/QRCodeData.cs
@@ -154,7 +154,6 @@ namespace QRCoder
             return rawData;
         }
 
-        [Obsolete("This constructor will be removed in version 2.0.0.")]
         public void SaveRawData(string filePath, Compression compressMode)
         {
             File.WriteAllBytes(filePath, GetRawData(compressMode));

--- a/QRCoder/QRCodeData.cs
+++ b/QRCoder/QRCodeData.cs
@@ -21,11 +21,12 @@ namespace QRCoder
             for (var i = 0; i < size; i++)
                 this.ModuleMatrix.Add(new BitArray(size));
         }
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0
+
+        [Obsolete("This constructor will be removed in version 2.0.0.")]
         public QRCodeData(string pathToRawData, Compression compressMode) : this(File.ReadAllBytes(pathToRawData), compressMode)
         {
         }
-#endif
+
         public QRCodeData(byte[] rawData, Compression compressMode)
         {
             var bytes = new List<byte>(rawData);
@@ -154,12 +155,11 @@ namespace QRCoder
             return rawData;
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0
+        [Obsolete("This constructor will be removed in version 2.0.0.")]
         public void SaveRawData(string filePath, Compression compressMode)
         {
             File.WriteAllBytes(filePath, GetRawData(compressMode));
         }
-#endif
 
         public int Version { get; private set; }
 

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1107,11 +1107,7 @@ namespace QRCoder
             Encoding utf8 = Encoding.UTF8;
             byte[] utfBytes = utf8.GetBytes(value);
             byte[] isoBytes = Encoding.Convert(utf8, iso, utfBytes);
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0
             return iso.GetString(isoBytes);
-#else
-            return iso.GetString(isoBytes, 0, isoBytes.Length);
-#endif
         }
 
         private static string PlainTextToBinaryByte(string plainText, EciMode eciMode, bool utf8BOM, bool forceUtf8)

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1026,8 +1026,7 @@ namespace QRCoder
         private static bool IsValidISO(string input)
         {
             var bytes = Encoding.GetEncoding("ISO-8859-1").GetBytes(input);
-            //var result = Encoding.GetEncoding("ISO-8859-1").GetString(bytes);
-            var result = Encoding.GetEncoding("ISO-8859-1").GetString(bytes,0,bytes.Length);
+            var result = Encoding.GetEncoding("ISO-8859-1").GetString(bytes);
             return String.Equals(input, result);
         }
 

--- a/QRCoder/QRCoder.csproj
+++ b/QRCoder/QRCoder.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0;net5.0;net5.0-windows;net6.0;net6.0-windows</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <DefineConstants Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'netstandard1.3'">$(DefineConstants);SYSTEM_DRAWING</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net5.0-windows'">$(DefineConstants);NET5_0_WINDOWS</DefineConstants>
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0-windows'">$(DefineConstants);NET6_0_WINDOWS</DefineConstants>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
@@ -48,9 +49,10 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net5.0' or '$(TargetFramework)' == 'net5.0-windows' ">
     <PackageReference Include="System.Drawing.Common" Version="5.0.3" />
   </ItemGroup>
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">
-		<PackageReference Include="System.Drawing.Common" Version="6.0.0" />
-	</ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0-windows' ">
+    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+  </ItemGroup>
 
   <PropertyGroup>
     <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>

--- a/QRCoder/SvgQRCode.cs
+++ b/QRCoder/SvgQRCode.cs
@@ -1,4 +1,4 @@
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0_OR_GREATER
+#if !NETSTANDARD1_3
 using QRCoder.Extensions;
 using System;
 using System.Collections;
@@ -267,14 +267,14 @@ namespace QRCoder
             private object _logoRaw;
             private bool _isEmbedded;
 
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING
             /// <summary>
             /// Create a logo object to be used in SvgQRCode renderer
             /// </summary>
             /// <param name="iconRasterized">Logo to be rendered as Bitmap/rasterized graphic</param>
             /// <param name="iconSizePercent">Degree of percentage coverage of the QR code by the logo</param>
             /// <param name="fillLogoBackground">If true, the background behind the logo will be cleaned</param>
-#if NET6_0_WINDOWS
+#if NET6_0_OR_GREATER
             [System.Runtime.Versioning.SupportedOSPlatform("windows")]
 #endif
             public SvgLogo(Bitmap iconRasterized, int iconSizePercent = 15, bool fillLogoBackground = true)

--- a/QRCoderTests/ArtQRCodeRendererTests.cs
+++ b/QRCoderTests/ArtQRCodeRendererTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_1 && !NET6_0
+﻿#if SYSTEM_DRAWING
 
 using Xunit;
 using QRCoder;
@@ -23,7 +23,7 @@ namespace QRCoderTests
             var bmp = new ArtQRCode(data).GetGraphic(10);
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("cb38c3156eaf13cdfba699bdafc3a84c");
+            result.ShouldBe("df510ce9feddc0dd8c23c54e700abbf0");
         }
 
         [Fact]
@@ -40,7 +40,7 @@ namespace QRCoderTests
             var bmp = new ArtQRCode(data).GetGraphic(10, Color.Black, Color.White, Color.Transparent, finderPatternImage: finder);
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("5df3f2892eeb01e9c282ad10f642dec2");
+            result.ShouldBe("e28a3779b9b975b85984e36f596c9a35");
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace QRCoderTests
             var bmp = new ArtQRCode(data).GetGraphic(10, Color.Black, Color.White, Color.Transparent, drawQuietZones: false);
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("632315c8695416fc82fe06a202688433");
+            result.ShouldBe("54408da26852d6c67ab7cad2656da7fa");
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace QRCoderTests
 
             var result = HelperFunctions.BitmapToHash(bmp);
 
-            result.ShouldBe("bbea08507282773175cfe7b52f0ddae4");
+            result.ShouldBe("7f039ccde219ae78e4f768466376a17f");
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace QRCoderTests
             //Create QR code
             var bmp = ArtQRCodeHelper.GetQRCode("A", 10, Color.Black, Color.White, Color.Transparent, QRCodeGenerator.ECCLevel.L);
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("57ecaa9bdeadcdcbeac8a19d734907ff");
+            result.ShouldBe("a1975852df9b537344468bd44d54abe0");
         }
     }
 }

--- a/QRCoderTests/Base64QRCodeRendererTests.cs
+++ b/QRCoderTests/Base64QRCodeRendererTests.cs
@@ -55,7 +55,7 @@ namespace QRCoderTests
             base64QRCode.ShouldBe(Convert.ToBase64String(pngCodeGfx));
         }
 
-#if NETFRAMEWORK || NETCOREAPP2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING
         [Fact]
         [Category("QRRenderer/Base64QRCode")]
         public void can_render_base64_qrcode_jpeg()

--- a/QRCoderTests/Helpers/CategoryDiscoverer.cs
+++ b/QRCoderTests/Helpers/CategoryDiscoverer.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-#if !NET35 && !NET452
+#if !NETFRAMEWORK
 using Xunit.Abstractions;
 #endif
 using Xunit.Sdk;
 
 namespace QRCoderTests.Helpers.XUnitExtenstions
 {
-#if NET35 || NET452
+#if NETFRAMEWORK
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class CategoryAttribute : Attribute
     {

--- a/QRCoderTests/PngByteQRCodeRendererTests.cs
+++ b/QRCoderTests/PngByteQRCodeRendererTests.cs
@@ -38,7 +38,7 @@ namespace QRCoderTests
             {
                 var bmp = (Bitmap)Image.FromStream(mStream);
                 var result = HelperFunctions.BitmapToHash(bmp);
-                result.ShouldBe("18b19e6037cff06ae995d8d487b0e46e");
+                result.ShouldBe("0cfc8a8d552ade875190d8e9f5c1e1bf");
             }
 #endif        
         }
@@ -60,7 +60,7 @@ namespace QRCoderTests
             {
                 var bmp = (Bitmap)Image.FromStream(mStream);
                 var result = HelperFunctions.BitmapToHash(bmp);
-                result.ShouldBe("37ae73e90b66beac317b790be3db24cc");
+                result.ShouldBe("88d394b2405499869feb69b81593e703");
             }
 #endif   
         }
@@ -83,7 +83,7 @@ namespace QRCoderTests
             {
                 var bmp = (Bitmap)Image.FromStream(mStream);
                 var result = HelperFunctions.BitmapToHash(bmp);
-                result.ShouldBe("c56c2a9535fd8e9a92a6ac9709d21e67");
+                result.ShouldBe("1d81b3d52fc64543186558eee7d9494b");
             }
 #endif   
         }
@@ -107,7 +107,7 @@ namespace QRCoderTests
                 var bmp = (Bitmap)Image.FromStream(mStream);
                 bmp.MakeTransparent(Color.Transparent);
                 var result = HelperFunctions.BitmapToHash(bmp);
-                result.ShouldBe("fbbc8255ebf3e4f4a1d21f0dd15f76f8");
+                result.ShouldBe("825a6469f89bf9e3d7318a5390d5ba7f");
             }
 #endif
         }
@@ -136,7 +136,7 @@ namespace QRCoderTests
             {
                 var bmp = (Bitmap)Image.FromStream(mStream);
                 var result = HelperFunctions.BitmapToHash(bmp);
-                result.ShouldBe("1978fb11ce26acf9b6cb7490b4c44ef2");
+                result.ShouldBe("a2ea116068eb516a7c210b2541e99348");
             }
 #endif  
         }
@@ -156,7 +156,7 @@ namespace QRCoderTests
             {
                 var bmp = (Bitmap)Image.FromStream(mStream);
                 var result = HelperFunctions.BitmapToHash(bmp);
-                result.ShouldBe("c56c2a9535fd8e9a92a6ac9709d21e67");
+                result.ShouldBe("1d81b3d52fc64543186558eee7d9494b");
             }
 #endif  
         }

--- a/QRCoderTests/QRCodeRendererTests.cs
+++ b/QRCoderTests/QRCodeRendererTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_1 && !NET6_0
+﻿#if SYSTEM_DRAWING
 using Xunit;
 using QRCoder;
 using Shouldly;
@@ -21,7 +21,7 @@ namespace QRCoderTests
             var bmp = new QRCode(data).GetGraphic(10);
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("e8c61b8f0455924fe08ba68686d0d296");
+            result.ShouldBe("f2ed5073bd42dc012e442c0f750e9dae");
         }
 
         [Fact]
@@ -33,7 +33,7 @@ namespace QRCoderTests
             var bmp = new QRCode(data).GetGraphic(10, "#000000", "#ffffff");
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("e8c61b8f0455924fe08ba68686d0d296");
+            result.ShouldBe("f2ed5073bd42dc012e442c0f750e9dae");
         }
 
 
@@ -46,7 +46,7 @@ namespace QRCoderTests
             var bmp = new QRCode(data).GetGraphic(5, Color.Black, Color.White, false);
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("d703e54a0ba541c6ea69e3d316e394e7");
+            result.ShouldBe("c401d45c01e636af3eb4b8ca6cd17d14");
         }
 
 
@@ -61,7 +61,7 @@ namespace QRCoderTests
             var bmp = new QRCode(data).GetGraphic(10, Color.Black, Color.Transparent, icon: (Bitmap)Image.FromFile(HelperFunctions.GetAssemblyPath() + "\\assets\\noun_software engineer_2909346.png"));
             //Used logo is licensed under public domain. Ref.: https://thenounproject.com/Iconathon1/collection/redefining-women/?i=2909346
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("150f8fc7dae4487ba2887d2b2bea1c25");
+            result.ShouldBe("c99a82b43ce48ddae18a75862c476a9e");
         }
 
         [Fact]
@@ -75,7 +75,7 @@ namespace QRCoderTests
             //Used logo is licensed under public domain. Ref.: https://thenounproject.com/Iconathon1/collection/redefining-women/?i=2909346
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("c46a7ec51bf978d7a882059c322ca69d");
+            result.ShouldBe("74808e52270bba92e7b821dbd067dfd2");
         }
 
         [Fact]
@@ -90,7 +90,7 @@ namespace QRCoderTests
             var bmp = new QRCode(data).GetGraphic(10, Color.Black, Color.Transparent, icon: logo, iconBorderWidth: 6);
             //Used logo is licensed under public domain. Ref.: https://thenounproject.com/Iconathon1/collection/redefining-women/?i=2909346
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("150f8fc7dae4487ba2887d2b2bea1c25");
+            result.ShouldBe("c99a82b43ce48ddae18a75862c476a9e");
         }
 
         [Fact]
@@ -105,7 +105,7 @@ namespace QRCoderTests
             var bmp = new QRCode(data).GetGraphic(10, Color.Black, Color.White, icon: logo, iconBorderWidth: 6);
             //Used logo is licensed under public domain. Ref.: https://thenounproject.com/Iconathon1/collection/redefining-women/?i=2909346
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("1c926ea1d48f42fdf8e6f1438b774cdd");
+            result.ShouldBe("943ecd2a847a4d9509ca0266dbbadd7b");
         }
 
         [Fact]
@@ -120,7 +120,7 @@ namespace QRCoderTests
             var bmp = new QRCode(data).GetGraphic(10, Color.Black, Color.Transparent, icon: logo, iconBorderWidth: 6, iconBackgroundColor: Color.DarkGreen);
             //Used logo is licensed under public domain. Ref.: https://thenounproject.com/Iconathon1/collection/redefining-women/?i=2909346
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("9a06bfbb72df999b6290b5af5c4037cb");
+            result.ShouldBe("e60bdaafe807889ca322d47146fe8300");
         }
 
 
@@ -141,7 +141,7 @@ namespace QRCoderTests
             var bmp = QRCodeHelper.GetQRCode("This is a quick test! 123#?", 10, Color.Black, Color.White, QRCodeGenerator.ECCLevel.H);
 
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("e8c61b8f0455924fe08ba68686d0d296");
+            result.ShouldBe("f2ed5073bd42dc012e442c0f750e9dae");
         }
 
     }

--- a/QRCoderTests/QRCoderTests.csproj
+++ b/QRCoderTests/QRCoderTests.csproj
@@ -3,6 +3,8 @@
 		<TargetFrameworks>net35;net452;netcoreapp1.1;netcoreapp2.0;net5.0;net5.0-windows;net6.0;net6.0-windows</TargetFrameworks>
 		<UseWindowsForms Condition="'$(TargetFramework)' == 'net5.0-windows'">true</UseWindowsForms>
 		<UseWPF Condition="'$(TargetFramework)' == 'net5.0-windows'">true</UseWPF>
+		<DefineConstants Condition="'$(TargetFramework)' != 'net6.0' AND '$(TargetFramework)' != 'netcoreapp1.1'">$(DefineConstants);SYSTEM_DRAWING</DefineConstants>
+		<DefineConstants Condition="'$(TargetFramework)' == 'net35' or '$(TargetFramework)' == 'net452' or '$(TargetFramework)' == 'net5.0-windows' or '$(TargetFramework)' == 'net6.0-windows'">$(DefineConstants);TEST_XAML</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net5.0-windows'">$(DefineConstants);NET5_0_WINDOWS</DefineConstants>
 		<DefineConstants Condition="'$(TargetFramework)' == 'net6.0-windows'">$(DefineConstants);NET6_0_WINDOWS</DefineConstants>
 		<IsPackable>false</IsPackable>

--- a/QRCoderTests/QRGeneratorTests.cs
+++ b/QRCoderTests/QRGeneratorTests.cs
@@ -140,12 +140,7 @@ namespace QRCoderTests
         public static string ToBitString(this BitArray bits)
         {
             var sb = new StringBuilder();
-            int bitLength = 0;
-#if !NETCOREAPP1_1
-            bitLength = bits.Count;
-#else
-            bitLength = bits.Length;
-#endif
+            int bitLength = bits.Length;
             for (int i = 0; i < bitLength; i++)
             {
                 char c = bits[i] ? '1' : '0';

--- a/QRCoderTests/SvgQRCodeRendererTests.cs
+++ b/QRCoderTests/SvgQRCodeRendererTests.cs
@@ -14,6 +14,15 @@ namespace QRCoderTests
 
     public class SvgQRCodeRendererTests
     {
+        private string GetAssemblyPath()
+        {
+            return
+#if NET5_0
+                AppDomain.CurrentDomain.BaseDirectory;
+#else
+                Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase).Replace("file:\\", "");
+#endif
+        }
 
         [Fact]
         [Category("QRRenderer/SvgQRCode")]
@@ -93,7 +102,7 @@ namespace QRCoderTests
             result.ShouldBe("4ab0417cc6127e347ca1b2322c49ed7d");
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0 || NET5_0 || NET6_0_WINDOWS
+#if SYSTEM_DRAWING && !NET5_0_OR_GREATER // .NET 5+ does not encode PNG images in a deterministic way, so the hash may be different across different runs
         [Fact]
         [Category("QRRenderer/SvgQRCode")]
         public void can_render_svg_qrcode_with_png_logo_bitmap()

--- a/QRCoderTests/SvgQRCodeRendererTests.cs
+++ b/QRCoderTests/SvgQRCodeRendererTests.cs
@@ -14,16 +14,6 @@ namespace QRCoderTests
 
     public class SvgQRCodeRendererTests
     {
-        private string GetAssemblyPath()
-        {
-            return
-#if NET5_0
-                AppDomain.CurrentDomain.BaseDirectory;
-#else
-                Path.GetDirectoryName(System.Reflection.Assembly.GetExecutingAssembly().CodeBase).Replace("file:\\", "");
-#endif
-        }
-
         [Fact]
         [Category("QRRenderer/SvgQRCode")]
         public void can_render_svg_qrcode_simple()

--- a/QRCoderTests/XamlQRCodeRendererTests.cs
+++ b/QRCoderTests/XamlQRCodeRendererTests.cs
@@ -1,4 +1,4 @@
-﻿#if NETFRAMEWORK || NET5_0_WINDOWS || NET6_0_WINDOWS
+﻿#if TEST_XAML
 using Xunit;
 using QRCoder;
 using QRCoder.Xaml;
@@ -22,7 +22,7 @@ namespace QRCoderTests
 
             var bmp = HelperFunctions.BitmapSourceToBitmap(xCode);
             var result = HelperFunctions.BitmapToHash(bmp);
-            result.ShouldBe("e8c61b8f0455924fe08ba68686d0d296");
+            result.ShouldBe("f2ed5073bd42dc012e442c0f750e9dae");
         }
 
 


### PR DESCRIPTION
Cleans up ifdefs

To the extent possible:
- `SYSTEM_DRAWING` is used for when System.Drawing.Common is available
- `NET6_0_OR_GREATER` is used to apply `SupportedOSPlatformAttribute` (maybe in future PR this is polyfilled)
- `!NETSTANDARD1_3` is used to exclude code that requires System.Drawing.Primitives

And for tests:
- `SYSTEM_DRAWING` is used for when System.Drawing.Common is available
- `TEST_XAML` is used for XAML tests
- `!NETCOREAPP1_1` is used to exclude tests for .NET Standard 1.1, and for hash checks for PNG tests

All other ifdefs are simplified and used as minimally as possible (e.g. `NETFRAMEWORK` vs `NET35 || NET40`)

Also, many tests were not performed on .NET 6, probably since the hashes don't match due to a new deflate algorithm.  Worse yet, they do not appear to be deterministic, so rerunning the test can produce a different hash.  I've changed the hashing algorithm to be deterministic based on the pixel values inside the `Bitmap`.  This only works on platforms with access to `Bitmap` so the PNG tests still have ifdefs when running on .NET Core 1.1.