### PR TITLE
Fix CI scripts

### DIFF
--- a/.github/workflows/wf-build-release-ci.yml
+++ b/.github/workflows/wf-build-release-ci.yml
@@ -146,7 +146,8 @@ jobs:
           1.0.x
           2.0.x
           5.0.x
-          6.0.x 
+          6.0.x
+          8.0.x
 
     - name: Restore dependencies
       run: dotnet restore

--- a/.github/workflows/wf-build-release.yml
+++ b/.github/workflows/wf-build-release.yml
@@ -146,7 +146,8 @@ jobs:
           1.0.x
           2.0.x
           5.0.x
-          6.0.x 
+          6.0.x
+          8.0.x
 
     - name: Restore dependencies
       run: dotnet restore


### PR DESCRIPTION
Installs missing .NET 8 SDKs

Fixes:
- https://github.com/codebude/QRCoder/pull/508#issuecomment-2084748723

> Hi @Shane32 seems like this PR broke the CI scripts. Can you have a look?
https://github.com/codebude/QRCoder/actions/runs/8884442673/job/24413893321

```shell
Run dotnet restore
  dotnet restore
  shell: C:\Program Files\PowerShell\7\pwsh.EXE -command ". '{0}'"
  env:
    GH_PKG_SEC: ***
    DOTNET_ROOT: C:\Program Files\dotnet
  Determining projects to restore...
Error: C:\Program Files\dotnet\sdk\7.0.[4](https://github.com/codebude/QRCoder/actions/runs/8884442673/job/24413893321#step:4:4)08\Sdks\Microsoft.NET.Sdk\targets\Microsoft.NET.TargetFrameworkInference.targets(160,[5](https://github.com/codebude/QRCoder/actions/runs/8884442673/job/24413893321#step:4:5)): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0.  Either target .NET [7](https://github.com/codebude/QRCoder/actions/runs/8884442673/job/24413893321#step:4:8).0 or lower, or use a version of the .NET SDK that supports .NET [8](https://github.com/codebude/QRCoder/actions/runs/8884442673/job/24413893321#step:4:9).0. Download the .NET SDK from https://aka.ms/dotnet/download [D:\a\QRCoder\QRCoder\QRCoderBenchmarks\QRCoderBenchmarks.csproj]
Error: Process completed with exit code 1.
```

_Originally posted by @codebude in https://github.com/codebude/QRCoder/issues/508#issuecomment-2084748723_
            