### PR TITLE
Utilize ArrayPool for ECC calculations

### DIFF
--- a/QRCoder/QRCodeGenerator.Polynom.cs
+++ b/QRCoder/QRCodeGenerator.Polynom.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 
 namespace QRCoder
 {
@@ -8,21 +10,132 @@ namespace QRCoder
         /// <summary>
         /// Represents a polynomial, which is a sum of polynomial terms.
         /// </summary>
-        private struct Polynom
+        private struct Polynom : IDisposable
         {
+            private PolynomItem[] _polyItems;
+            private int _length;
+
             /// <summary>
             /// Initializes a new instance of the <see cref="Polynom"/> struct with a specified number of initial capacity for polynomial terms.
             /// </summary>
             /// <param name="count">The initial capacity of the polynomial items list.</param>
             public Polynom(int count)
             {
-                this.PolyItems = new List<PolynomItem>(count);
+                _length = 0;
+                _polyItems = Allocate(count);
             }
 
             /// <summary>
-            /// Gets or sets the list of polynomial items, where each item represents a term in the polynomial.
+            /// Adds a polynomial term to the polynomial.
             /// </summary>
-            public List<PolynomItem> PolyItems { get; set; }
+            public void Add(PolynomItem item)
+            {
+                EnsureCapacity(_length + 1);
+                _polyItems[_length++] = item;
+            }
+
+            /// <summary>
+            /// Removes the polynomial term at the specified index.
+            /// </summary>
+            public void RemoveAt(int index)
+            {
+                if (index < 0 || index >= _length)
+                    throw new IndexOutOfRangeException();
+
+                if (index < _length - 1)
+                    Array.Copy(_polyItems, index + 1, _polyItems, index, _length - index - 1);
+
+                _length--;
+            }
+
+            /// <summary>
+            /// Gets or sets a polynomial term at the specified index.
+            /// </summary>
+            public PolynomItem this[int index]
+            {
+                get {
+                    if (index < 0 || index >= _length)
+                        throw new IndexOutOfRangeException();
+                    return _polyItems[index];
+                }
+                set {
+                    if (index < 0 || index >= _length)
+                        throw new IndexOutOfRangeException();
+                    _polyItems[index] = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets the number of polynomial terms in the polynomial.
+            /// </summary>
+            public int Count => _length;
+
+            /// <summary>
+            /// Removes all polynomial terms from the polynomial.
+            /// </summary>
+            public void Clear()
+            {
+                _length = 0;
+            }
+
+            /// <summary>
+            /// Clones the polynomial, creating a new instance with the same polynomial terms.
+            /// </summary>
+            public Polynom Clone()
+            {
+                var newPolynom = new Polynom(_length);
+                Array.Copy(_polyItems, newPolynom._polyItems, _length);
+                newPolynom._length = _length;
+                return newPolynom;
+            }
+
+            /// <summary>
+            /// Sorts the collection of <see cref="PolynomItem"/> using a custom comparer function.
+            /// </summary>
+            /// <param name="comparer">
+            /// A function that compares two <see cref="PolynomItem"/> objects and returns an integer indicating their relative order:
+            /// less than zero if the first is less than the second, zero if they are equal, or greater than zero if the first is greater than the second.
+            /// </param>
+            public void Sort(Func<PolynomItem, PolynomItem, int> comparer)
+            {
+                if (comparer == null) throw new ArgumentNullException(nameof(comparer));
+
+                // Assuming you have a list or array to sort within your class
+                var items = _polyItems;
+                if (items == null || _length <= 1)
+                {
+                    return; // Nothing to sort if the list is empty or contains only one element
+                }
+
+                void QuickSort(int left, int right)
+                {
+                    int i = left;
+                    int j = right;
+                    PolynomItem pivot = items[(left + right) / 2];
+
+                    while (i <= j)
+                    {
+                        while (comparer(items[i], pivot) < 0) i++;
+                        while (comparer(items[j], pivot) > 0) j--;
+
+                        if (i <= j)
+                        {
+                            // Swap items[i] and items[j]
+                            PolynomItem temp = items[i];
+                            items[i] = items[j];
+                            items[j] = temp;
+                            i++;
+                            j--;
+                        }
+                    }
+
+                    // Recursively sort the sub-arrays
+                    if (left < j) QuickSort(left, j);
+                    if (i < right) QuickSort(i, right);
+                }
+
+                QuickSort(0, _length - 1);
+            }
 
             /// <summary>
             /// Returns a string that represents the polynomial in standard algebraic notation.
@@ -32,7 +145,7 @@ namespace QRCoder
             {
                 var sb = new StringBuilder();
 
-                foreach (var polyItem in this.PolyItems)
+                foreach (var polyItem in _polyItems)
                 {
                     sb.Append("a^" + polyItem.Coefficient + "*x^" + polyItem.Exponent + " + ");
                 }
@@ -42,6 +155,134 @@ namespace QRCoder
                     sb.Length -= 3;
 
                 return sb.ToString();
+            }
+
+            /// <inheritdoc/>
+            public void Dispose()
+            {
+                Free(_polyItems);
+                _polyItems = null;
+            }
+
+            /// <summary>
+            /// Ensures that the polynomial has enough capacity to store the specified number of polynomial terms.
+            /// </summary>
+            private void EnsureCapacity(int min)
+            {
+                if (_polyItems.Length < min)
+                {
+                    // All math by QRCoder should be done with fixed polynomials, so we don't need to grow the capacity.
+                    ThrowNotSupportedException();
+
+                    // Sample code for growing the capacity:
+                    //var newArray = Allocate(Math.Max(min - 1, 8) * 2); // Grow by 2x, but at least by 8
+                    //Array.Copy(_polyItems, newArray, _length);
+                    //Free(_polyItems);
+                    //_polyItems = newArray;
+                }
+
+                void ThrowNotSupportedException()
+                {
+                    throw new NotSupportedException("The polynomial capacity is fixed and cannot be increased.");
+                }
+            }
+
+#if NETCOREAPP
+            /// <summary>
+            /// Allocates memory for the polynomial terms.
+            /// </summary>
+            private static PolynomItem[] Allocate(int count)
+            {
+                return System.Buffers.ArrayPool<PolynomItem>.Shared.Rent(count);
+            }
+
+            /// <summary>
+            /// Frees memory allocated for the polynomial terms.
+            /// </summary>
+            private static void Free(PolynomItem[] array)
+            {
+                System.Buffers.ArrayPool<PolynomItem>.Shared.Return(array);
+            }
+#else
+            // Implement a poor-man's array pool for .NET Framework
+            [ThreadStatic]
+            private static List<PolynomItem[]> _arrayPool;
+
+            /// <summary>
+            /// Allocates memory for the polynomial terms.
+            /// </summary>
+            private static PolynomItem[] Allocate(int count)
+            {
+                if (count <= 0)
+                    ThrowArgumentOutOfRangeException();
+
+                // Search for a suitable array in the thread-local pool, if it has been initialized
+                if (_arrayPool != null)
+                {
+                    for (int i = 0; i < _arrayPool.Count; i++)
+                    {
+                        var array = _arrayPool[i];
+                        if (array.Length >= count)
+                        {
+                            _arrayPool.RemoveAt(i);
+                            return array;
+                        }
+                    }
+                }
+
+                // No suitable buffer found; create a new one
+                return new PolynomItem[count];
+
+                void ThrowArgumentOutOfRangeException()
+                {
+                    throw new ArgumentOutOfRangeException(nameof(count), "The count must be a positive number.");
+                }
+            }
+
+            /// <summary>
+            /// Frees memory allocated for the polynomial terms.
+            /// </summary>
+            private static void Free(PolynomItem[] array)
+            {
+                if (array == null)
+                    ThrowArgumentNullException();
+
+                // Initialize the thread-local pool if it's not already done
+                if (_arrayPool == null)
+                    _arrayPool = new List<PolynomItem[]>(8);
+
+                // Add the buffer back to the pool
+                _arrayPool.Add(array);
+
+                void ThrowArgumentNullException()
+                {
+                    throw new ArgumentNullException(nameof(array));
+                }
+            }
+#endif
+
+            /// <summary>
+            /// Returns an enumerator that iterates through the polynomial terms.
+            /// </summary>
+            public PolynumEnumerator GetEnumerator() => new PolynumEnumerator(this);
+
+            /// <summary>
+            /// Value type enumerator for the <see cref="Polynom"/> struct.
+            /// </summary>
+            public struct PolynumEnumerator
+            {
+                private Polynom _polynom;
+                private int _index;
+
+                public PolynumEnumerator(Polynom polynom)
+                {
+                    _polynom = polynom;
+                    _index = -1;
+                }
+
+                public PolynomItem Current => _polynom[_index];
+
+                public bool MoveNext() => ++_index < _polynom._length;
             }
         }
     }

--- a/QRCoder/QRCodeGenerator.Polynom.cs
+++ b/QRCoder/QRCodeGenerator.Polynom.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using System.Threading;
 
 namespace QRCoder
 {

--- a/QRCoder/QRCodeGenerator.Polynom.cs
+++ b/QRCoder/QRCodeGenerator.Polynom.cs
@@ -99,7 +99,6 @@ namespace QRCoder
             {
                 if (comparer == null) throw new ArgumentNullException(nameof(comparer));
 
-                // Assuming you have a list or array to sort within your class
                 var items = _polyItems;
                 if (items == null || _length <= 1)
                 {

--- a/QRCoder/QRCodeGenerator.Polynom.cs
+++ b/QRCoder/QRCodeGenerator.Polynom.cs
@@ -38,7 +38,7 @@ namespace QRCoder
             /// </summary>
             public void RemoveAt(int index)
             {
-                if (index < 0 || index >= _length)
+                if ((uint)index >= (uint)_length)
                     throw new IndexOutOfRangeException();
 
                 if (index < _length - 1)

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -223,13 +223,15 @@ namespace QRCoder
             }
 
             // Generate the generator polynomial using the number of ECC words.
-            var generatorPolynom = CalculateGeneratorPolynom(eccInfo.ECCPerBlock);
-            //Calculate error correction words
-            var codeWordWithECC = new List<CodewordBlock>(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2);
-            AddCodeWordBlocks(1, eccInfo.BlocksInGroup1, eccInfo.CodewordsInGroup1, bitArray, 0, bitArray.Length);
-            int offset = eccInfo.BlocksInGroup1 * eccInfo.CodewordsInGroup1 * 8;
-            AddCodeWordBlocks(2, eccInfo.BlocksInGroup2, eccInfo.CodewordsInGroup2, bitArray, offset, bitArray.Length - offset);
-
+            List<CodewordBlock> codeWordWithECC;
+            using (var generatorPolynom = CalculateGeneratorPolynom(eccInfo.ECCPerBlock))
+            {
+                //Calculate error correction words
+                codeWordWithECC = new List<CodewordBlock>(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2);
+                AddCodeWordBlocks(1, eccInfo.BlocksInGroup1, eccInfo.CodewordsInGroup1, bitArray, 0, bitArray.Length, generatorPolynom);
+                int offset = eccInfo.BlocksInGroup1 * eccInfo.CodewordsInGroup1 * 8;
+                AddCodeWordBlocks(2, eccInfo.BlocksInGroup2, eccInfo.CodewordsInGroup2, bitArray, offset, bitArray.Length - offset, generatorPolynom);
+            }
 
             //Calculate interleaved code word lengths
             int interleavedLength = 0;
@@ -287,7 +289,7 @@ namespace QRCoder
             ModulePlacer.AddQuietZone(qr);
             return qr;
 
-            void AddCodeWordBlocks(int blockNum, int blocksInGroup, int codewordsInGroup, BitArray bitArray2, int offset2, int count)
+            void AddCodeWordBlocks(int blockNum, int blocksInGroup, int codewordsInGroup, BitArray bitArray2, int offset2, int count, Polynom generatorPolynom)
             {
                 var groupLength = codewordsInGroup * 8;
                 for (var i = 0; i < blocksInGroup; i++)
@@ -440,44 +442,61 @@ namespace QRCoder
         /// This method applies polynomial division, using the message polynomial and a generator polynomial,
         /// to compute the remainder which forms the ECC codewords.
         /// </summary>
-        private static byte[] CalculateECCWords(BitArray bitArray, int offset, int count, ECCInfo eccInfo, Polynom generatorPolynom)
+        private static byte[] CalculateECCWords(BitArray bitArray, int offset, int count, ECCInfo eccInfo, Polynom generatorPolynomBase)
         {
             var eccWords = eccInfo.ECCPerBlock;
             // Calculate the message polynomial from the bit array data.
             var messagePolynom = CalculateMessagePolynom(bitArray, offset, count);
+            var generatorPolynom = generatorPolynomBase.Clone();
 
             // Adjust the exponents in the message polynomial to account for ECC length.
-            for (var i = 0; i < messagePolynom.PolyItems.Count; i++)
-                messagePolynom.PolyItems[i] = new PolynomItem(messagePolynom.PolyItems[i].Coefficient,
-                    messagePolynom.PolyItems[i].Exponent + eccWords);
+            for (var i = 0; i < messagePolynom.Count; i++)
+                messagePolynom[i] = new PolynomItem(messagePolynom[i].Coefficient,
+                    messagePolynom[i].Exponent + eccWords);
 
             // Adjust the generator polynomial exponents based on the message polynomial.
-            for (var i = 0; i < generatorPolynom.PolyItems.Count; i++)
-                generatorPolynom.PolyItems[i] = new PolynomItem(generatorPolynom.PolyItems[i].Coefficient,
-                    generatorPolynom.PolyItems[i].Exponent + (messagePolynom.PolyItems.Count - 1));
+            for (var i = 0; i < generatorPolynom.Count; i++)
+                generatorPolynom[i] = new PolynomItem(generatorPolynom[i].Coefficient,
+                    generatorPolynom[i].Exponent + (messagePolynom.Count - 1));
 
             // Divide the message polynomial by the generator polynomial to find the remainder.
             var leadTermSource = messagePolynom;
-            for (var i = 0; (leadTermSource.PolyItems.Count > 0 && leadTermSource.PolyItems[leadTermSource.PolyItems.Count - 1].Exponent > 0); i++)
+            for (var i = 0; (leadTermSource.Count > 0 && leadTermSource[leadTermSource.Count - 1].Exponent > 0); i++)
             {
-                if (leadTermSource.PolyItems[0].Coefficient == 0)  // Simplify the polynomial if the leading coefficient is zero.
+                if (leadTermSource[0].Coefficient == 0)  // Simplify the polynomial if the leading coefficient is zero.
                 {
-                    leadTermSource.PolyItems.RemoveAt(0);
-                    leadTermSource.PolyItems.Add(new PolynomItem(0, leadTermSource.PolyItems[leadTermSource.PolyItems.Count - 1].Exponent - 1));
+                    leadTermSource.RemoveAt(0);
+                    leadTermSource.Add(new PolynomItem(0, leadTermSource[leadTermSource.Count - 1].Exponent - 1));
                 }
                 else  // Otherwise, perform polynomial reduction using XOR and multiplication with the generator polynomial.
                 {
-                    var resPoly = MultiplyGeneratorPolynomByLeadterm(generatorPolynom, ConvertToAlphaNotation(leadTermSource).PolyItems[0], i);
+                    // Convert the first coefficient to its corresponding alpha exponent unless it's zero.
+                    // Coefficients that are zero remain zero because log(0) is undefined.
+                    var index0Coefficient = leadTermSource[0].Coefficient;
+                    index0Coefficient = index0Coefficient == 0 ? 0 : GetAlphaExpFromIntVal(index0Coefficient);
+                    var alphaNotation = new PolynomItem(index0Coefficient, leadTermSource[0].Exponent);
+                    var resPoly = MultiplyGeneratorPolynomByLeadterm(generatorPolynom, alphaNotation, i);
                     ConvertToDecNotationInPlace(resPoly);
-                    resPoly = XORPolynoms(leadTermSource, resPoly);
-                    leadTermSource = resPoly;
+                    var newPoly = XORPolynoms(leadTermSource, resPoly);
+                    // Free memory used by the previous polynomials.
+                    resPoly.Dispose();
+                    leadTermSource.Dispose();
+                    // Update the message polynomial with the new remainder.
+                    leadTermSource = newPoly;
                 }
             }
 
+            // Free memory used by the generator polynomial.
+            generatorPolynom.Dispose();
+
             // Convert the resulting polynomial into a byte array representing the ECC codewords.
-            var ret = new byte[leadTermSource.PolyItems.Count];
-            for (var i = 0; i < leadTermSource.PolyItems.Count; i++)
-                ret[i] = (byte)leadTermSource.PolyItems[i].Coefficient;
+            var ret = new byte[leadTermSource.Count];
+            for (var i = 0; i < leadTermSource.Count; i++)
+                ret[i] = (byte)leadTermSource[i].Coefficient;
+
+            // Free memory used by the message polynomial.
+            leadTermSource.Dispose();
+
             return ret;
         }
 
@@ -488,18 +507,18 @@ namespace QRCoder
         /// </summary>
         private static Polynom ConvertToAlphaNotation(Polynom poly)
         {
-            var newPoly = new Polynom(poly.PolyItems.Count);
+            var newPoly = new Polynom(poly.Count);
 
-            for (var i = 0; i < poly.PolyItems.Count; i++)
+            for (var i = 0; i < poly.Count; i++)
             {
                 // Convert each coefficient to its corresponding alpha exponent unless it's zero.
                 // Coefficients that are zero remain zero because log(0) is undefined.
-                newPoly.PolyItems.Add(
+                newPoly.Add(
                     new PolynomItem(
-                        (poly.PolyItems[i].Coefficient != 0
-                            ? GetAlphaExpFromIntVal(poly.PolyItems[i].Coefficient)
+                        (poly[i].Coefficient != 0
+                            ? GetAlphaExpFromIntVal(poly[i].Coefficient)
                             : 0),
-                        poly.PolyItems[i].Exponent)); // The exponent remains unchanged.
+                        poly[i].Exponent)); // The exponent remains unchanged.
             }
 
             return newPoly;
@@ -511,10 +530,10 @@ namespace QRCoder
         /// </summary>
         private static void ConvertToDecNotationInPlace(Polynom poly)
         {
-            for (var i = 0; i < poly.PolyItems.Count; i++)
+            for (var i = 0; i < poly.Count; i++)
             {
                 // Convert the alpha exponent of the coefficient to its decimal value and create a new polynomial item with the updated coefficient.
-                poly.PolyItems[i] = new PolynomItem(GetIntValFromAlphaExp(poly.PolyItems[i].Coefficient), poly.PolyItems[i].Exponent);
+                poly[i] = new PolynomItem(GetIntValFromAlphaExp(poly[i].Coefficient), poly[i].Exponent);
             }
         }
 
@@ -587,7 +606,7 @@ namespace QRCoder
             var messagePol = new Polynom(count /= 8);
             for (var i = count - 1; i >= 0; i--)
             {
-                messagePol.PolyItems.Add(new PolynomItem(BinToDec(bitArray, offset, 8), i));
+                messagePol.Add(new PolynomItem(BinToDec(bitArray, offset, 8), i));
                 offset += 8;
             }
             return messagePol;
@@ -601,19 +620,23 @@ namespace QRCoder
         private static Polynom CalculateGeneratorPolynom(int numEccWords)
         {
             var generatorPolynom = new Polynom(2); // Start with the simplest form of the polynomial
-            generatorPolynom.PolyItems.Add(new PolynomItem(0, 1));
-            generatorPolynom.PolyItems.Add(new PolynomItem(0, 0));
+            generatorPolynom.Add(new PolynomItem(0, 1));
+            generatorPolynom.Add(new PolynomItem(0, 0));
 
-            var multiplierPolynom = new Polynom(numEccWords * 2); // Used for polynomial multiplication
-            for (var i = 1; i <= numEccWords - 1; i++)
+            using (var multiplierPolynom = new Polynom(numEccWords * 2)) // Used for polynomial multiplication
             {
-                // Clear and set up the multiplier polynomial for the current multiplication
-                multiplierPolynom.PolyItems.Clear();
-                multiplierPolynom.PolyItems.Add(new PolynomItem(0, 1));
-                multiplierPolynom.PolyItems.Add(new PolynomItem(i, 0));
+                for (var i = 1; i <= numEccWords - 1; i++)
+                {
+                    // Clear and set up the multiplier polynomial for the current multiplication
+                    multiplierPolynom.Clear();
+                    multiplierPolynom.Add(new PolynomItem(0, 1));
+                    multiplierPolynom.Add(new PolynomItem(i, 0));
 
-                // Multiply the generator polynomial by the current multiplier polynomial
-                generatorPolynom = MultiplyAlphaPolynoms(generatorPolynom, multiplierPolynom);
+                    // Multiply the generator polynomial by the current multiplier polynomial
+                    var newGeneratorPolynom = MultiplyAlphaPolynoms(generatorPolynom, multiplierPolynom);
+                    generatorPolynom.Dispose();
+                    generatorPolynom = newGeneratorPolynom;
+                }
             }
 
             return generatorPolynom; // Return the completed generator polynomial
@@ -956,9 +979,9 @@ namespace QRCoder
         private static Polynom XORPolynoms(Polynom messagePolynom, Polynom resPolynom)
         {
             // Determine the larger of the two polynomials to guide the XOR operation.
-            var resultPolynom = new Polynom(Math.Max(messagePolynom.PolyItems.Count, resPolynom.PolyItems.Count));
+            var resultPolynom = new Polynom(Math.Max(messagePolynom.Count, resPolynom.Count) - 1);
             Polynom longPoly, shortPoly;
-            if (messagePolynom.PolyItems.Count >= resPolynom.PolyItems.Count)
+            if (messagePolynom.Count >= resPolynom.Count)
             {
                 longPoly = messagePolynom;
                 shortPoly = resPolynom;
@@ -970,16 +993,16 @@ namespace QRCoder
             }
 
             // XOR the coefficients of the two polynomials.
-            for (var i = 0; i < longPoly.PolyItems.Count; i++)
+            for (var i = 1; i < longPoly.Count; i++)
             {
                 var polItemRes = new PolynomItem(
-                    longPoly.PolyItems[i].Coefficient ^
-                    (shortPoly.PolyItems.Count > i ? shortPoly.PolyItems[i].Coefficient : 0),
-                    messagePolynom.PolyItems[0].Exponent - i
+                    longPoly[i].Coefficient ^
+                    (shortPoly.Count > i ? shortPoly[i].Coefficient : 0),
+                    messagePolynom[0].Exponent - i
                 );
-                resultPolynom.PolyItems.Add(polItemRes);
+                resultPolynom.Add(polItemRes);
             }
-            resultPolynom.PolyItems.RemoveAt(0);
+
             return resultPolynom;
         }
 
@@ -989,15 +1012,15 @@ namespace QRCoder
         /// </summary>
         private static Polynom MultiplyGeneratorPolynomByLeadterm(Polynom genPolynom, PolynomItem leadTerm, int lowerExponentBy)
         {
-            var resultPolynom = new Polynom(genPolynom.PolyItems.Count);
-            foreach (var polItemBase in genPolynom.PolyItems)
+            var resultPolynom = new Polynom(genPolynom.Count);
+            foreach (var polItemBase in genPolynom)
             {
                 var polItemRes = new PolynomItem(
 
                     (polItemBase.Coefficient + leadTerm.Coefficient) % 255,
                     polItemBase.Exponent - lowerExponentBy
                 );
-                resultPolynom.PolyItems.Add(polItemRes);
+                resultPolynom.Add(polItemRes);
             }
             return resultPolynom;
         }
@@ -1011,12 +1034,12 @@ namespace QRCoder
         private static Polynom MultiplyAlphaPolynoms(Polynom polynomBase, Polynom polynomMultiplier)
         {
             // Initialize a new polynomial with a size based on the product of the sizes of the two input polynomials.
-            var resultPolynom = new Polynom(polynomMultiplier.PolyItems.Count * polynomBase.PolyItems.Count);
+            var resultPolynom = new Polynom(polynomMultiplier.Count * polynomBase.Count);
 
             // Multiply each term of the first polynomial by each term of the second polynomial.
-            foreach (var polItemBase in polynomMultiplier.PolyItems)
+            foreach (var polItemBase in polynomMultiplier)
             {
-                foreach (var polItemMulti in polynomBase.PolyItems)
+                foreach (var polItemMulti in polynomBase)
                 {
                     // Create a new polynomial term with the coefficients added (as exponents) and exponents summed.
                     var polItemRes = new PolynomItem
@@ -1024,18 +1047,18 @@ namespace QRCoder
                         ShrinkAlphaExp(polItemBase.Coefficient + polItemMulti.Coefficient),
                         (polItemBase.Exponent + polItemMulti.Exponent)
                     );
-                    resultPolynom.PolyItems.Add(polItemRes);
+                    resultPolynom.Add(polItemRes);
                 }
             }
 
             // Identify and merge terms with the same exponent.
-            var toGlue = GetNotUniqueExponents(resultPolynom.PolyItems);
+            var toGlue = GetNotUniqueExponents(resultPolynom);
             var gluedPolynoms = new PolynomItem[toGlue.Length];
             var gluedPolynomsIndex = 0;
             foreach (var exponent in toGlue)
             {
                 var coefficient = 0;
-                foreach (var polynomOld in resultPolynom.PolyItems)
+                foreach (var polynomOld in resultPolynom)
                 {
                     if (polynomOld.Exponent == exponent)
                         coefficient ^= GetIntValFromAlphaExp(polynomOld.Coefficient);
@@ -1047,18 +1070,18 @@ namespace QRCoder
             }
 
             // Remove duplicated exponents and add the corrected ones back.
-            for (int i = resultPolynom.PolyItems.Count - 1; i >= 0; i--)
-                if (toGlue.Contains(resultPolynom.PolyItems[i].Exponent))
-                    resultPolynom.PolyItems.RemoveAt(i);
+            for (int i = resultPolynom.Count - 1; i >= 0; i--)
+                if (toGlue.Contains(resultPolynom[i].Exponent))
+                    resultPolynom.RemoveAt(i);
             foreach (var polynom in gluedPolynoms)
-                resultPolynom.PolyItems.Add(polynom);
+                resultPolynom.Add(polynom);
 
             // Sort the polynomial terms by exponent in descending order.
-            resultPolynom.PolyItems.Sort((x, y) => -x.Exponent.CompareTo(y.Exponent));
+            resultPolynom.Sort((x, y) => -x.Exponent.CompareTo(y.Exponent));
             return resultPolynom;
 
             // Auxiliary function to identify exponents that appear more than once in the polynomial.
-            int[] GetNotUniqueExponents(List<PolynomItem> list)
+            int[] GetNotUniqueExponents(Polynom list)
             {
                 var dic = new Dictionary<int, bool>(list.Count);
                 foreach (var row in list)

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -222,6 +222,8 @@ namespace QRCoder
                 }
             }
 
+            // Generate the generator polynomial using the number of ECC words.
+            var generatorPolynom = CalculateGeneratorPolynom(eccInfo.ECCPerBlock);
             //Calculate error correction words
             var codeWordWithECC = new List<CodewordBlock>(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2);
             AddCodeWordBlocks(1, eccInfo.BlocksInGroup1, eccInfo.CodewordsInGroup1, bitArray, 0, bitArray.Length);
@@ -291,7 +293,7 @@ namespace QRCoder
                 for (var i = 0; i < blocksInGroup; i++)
                 {
                     var bitBlockList = BinaryStringToBitBlockByteList(bitArray2, offset2, groupLength);
-                    var eccWordList = CalculateECCWords(bitArray2, offset2, groupLength, eccInfo);
+                    var eccWordList = CalculateECCWords(bitArray2, offset2, groupLength, eccInfo, generatorPolynom);
                     codeWordWithECC.Add(new CodewordBlock(
                                           bitBlockList,
                                           eccWordList)
@@ -438,13 +440,11 @@ namespace QRCoder
         /// This method applies polynomial division, using the message polynomial and a generator polynomial,
         /// to compute the remainder which forms the ECC codewords.
         /// </summary>
-        private static byte[] CalculateECCWords(BitArray bitArray, int offset, int count, ECCInfo eccInfo)
+        private static byte[] CalculateECCWords(BitArray bitArray, int offset, int count, ECCInfo eccInfo, Polynom generatorPolynom)
         {
             var eccWords = eccInfo.ECCPerBlock;
             // Calculate the message polynomial from the bit array data.
             var messagePolynom = CalculateMessagePolynom(bitArray, offset, count);
-            // Generate the generator polynomial using the number of ECC words.
-            var generatorPolynom = CalculateGeneratorPolynom(eccWords);
 
             // Adjust the exponents in the message polynomial to account for ECC length.
             for (var i = 0; i < messagePolynom.PolyItems.Count; i++)

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -501,30 +501,6 @@ namespace QRCoder
         }
 
         /// <summary>
-        /// Converts the coefficients of a polynomial from integer values to their corresponding alpha exponent notation
-        /// based on a Galois field mapping. This is typically used in error correction calculations where
-        /// operations are performed on exponents rather than coefficients directly.
-        /// </summary>
-        private static Polynom ConvertToAlphaNotation(Polynom poly)
-        {
-            var newPoly = new Polynom(poly.Count);
-
-            for (var i = 0; i < poly.Count; i++)
-            {
-                // Convert each coefficient to its corresponding alpha exponent unless it's zero.
-                // Coefficients that are zero remain zero because log(0) is undefined.
-                newPoly.Add(
-                    new PolynomItem(
-                        (poly[i].Coefficient != 0
-                            ? GetAlphaExpFromIntVal(poly[i].Coefficient)
-                            : 0),
-                        poly[i].Exponent)); // The exponent remains unchanged.
-            }
-
-            return newPoly;
-        }
-
-        /// <summary>
         /// Converts all polynomial item coefficients from their alpha exponent notation to decimal representation in place.
         /// This conversion facilitates operations that require polynomial coefficients in their integer forms.
         /// </summary>

--- a/QRCoderBenchmarks/QRCodeGenerator.cs
+++ b/QRCoderBenchmarks/QRCodeGenerator.cs
@@ -20,4 +20,12 @@ public class QRCodeGenerator
         QRCoder.QRCodeGenerator qrGenerator = new QRCoder.QRCodeGenerator();
         _ = qrGenerator.CreateQrCode(payload, QRCoder.QRCodeGenerator.ECCLevel.H);
     }
+
+    [Benchmark]
+    public void CreateQRCodeLongest()
+    {
+        var str = new string('a', 2600);
+        QRCoder.QRCodeGenerator qrGenerator = new QRCoder.QRCodeGenerator();
+        _ = qrGenerator.CreateQrCode(str, QRCoder.QRCodeGenerator.ECCLevel.L);
+    }
 }


### PR DESCRIPTION
Improves performance by calculating `generatorPolynom` only a single time and renting arrays from `ArrayPool`.  Basically I rewrote `Polynom` to function similar to `List<PolynomItem>` with methods such as `Add`, `Clear` and `Sort`.  It's a struct so it does not require a heap allocation itself (no change), and the underlying buffer is rented from the array pool.  Calling `Dispose` on the `Polynom` will return the array back to the array pool.

## Before

| Method           | Mean       | Error   | StdDev  | Gen0    | Allocated |
|----------------- |-----------:|--------:|--------:|--------:|----------:|
| CreateQRCode     |   107.2 us | 0.66 us | 0.62 us |  1.2207 |  23.18 KB |
| CreateQRCodeLong | 1,878.4 us | 4.68 us | 4.15 us | 23.4375 | 433.53 KB |

## After - via ArrayPool<T>.Shared

| Method           | Mean        | Error    | StdDev   | Gen0   | Allocated |
|----------------- |------------:|---------:|---------:|-------:|----------:|
| CreateQRCode     |    99.44 us | 0.506 us | 0.448 us | 0.7324 |  14.68 KB |
| CreateQRCodeLong | 1,637.04 us | 2.811 us | 2.347 us | 1.9531 |  45.75 KB |

## After - via custom array pool implementation (for use with .NET Framework)

| Method           | Mean        | Error    | StdDev   | Gen0   | Allocated |
|----------------- |------------:|---------:|---------:|-------:|----------:|
| CreateQRCode     |    98.51 us | 0.188 us | 0.157 us | 0.7324 |  14.68 KB |
| CreateQRCodeLong | 1,706.09 us | 2.382 us | 2.112 us | 1.9531 |  45.75 KB |

