### PR TITLE
Updated codecov uploader configs

### DIFF
--- a/.github/workflows/wf-build-release-ci.yml
+++ b/.github/workflows/wf-build-release-ci.yml
@@ -95,6 +95,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.netcoreapp2.0.opencover.xml
         flags: netcoreapp2.0
 
@@ -102,6 +104,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0.opencover.xml
         flags: net5.0
 
@@ -109,6 +113,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0-windows.opencover.xml
         flags: net5.0-windows
 
@@ -116,6 +122,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0.opencover.xml
         flags: net6.0
 
@@ -123,6 +131,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0-windows.opencover.xml
         flags: net6.0-windows
 

--- a/.github/workflows/wf-build-release.yml
+++ b/.github/workflows/wf-build-release.yml
@@ -96,6 +96,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.netcoreapp2.0.opencover.xml
         flags: netcoreapp2.0
 
@@ -103,6 +105,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0.opencover.xml
         flags: net5.0
 
@@ -110,6 +114,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0-windows.opencover.xml
         flags: net5.0-windows
 
@@ -117,6 +123,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0.opencover.xml
         flags: net6.0
 
@@ -124,6 +132,8 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        disable_search: true
+        fail_ci_if_error: true
         files: ./QRCoderTests/coverage.net5.0-windows.opencover.xml
         flags: net6.0-windows
 


### PR DESCRIPTION
## Summary
Minor adjustments on codecov upload action in Github workflows. After updating the codecov action from v2 to v4 in addition to the file parameter (which was defined an used all the time) the uploader also searches for additional files. This breaks our coverage file tagging per platform.

Thus added the `disable_search` parameter.