### PR TITLE
Change MaskPattern.Patterns to a list

### DIFF
--- a/QRCoder/QRCodeGenerator.ModulePlacer.MaskPattern.cs
+++ b/QRCoder/QRCodeGenerator.ModulePlacer.MaskPattern.cs
@@ -17,10 +17,10 @@ namespace QRCoder
                 /// <summary>
                 /// A dictionary mapping each mask pattern index to its corresponding function that calculates whether a given pixel should be masked.
                 /// </summary>
-                public static readonly Dictionary<int, Func<int, int, bool>> Patterns =
-                    new Dictionary<int, Func<int, int, bool>>(8) {
-                        { 1, MaskPattern.Pattern1 }, {2, MaskPattern.Pattern2 }, {3, MaskPattern.Pattern3 }, {4, MaskPattern.Pattern4 },
-                        { 5, MaskPattern.Pattern5 }, {6, MaskPattern.Pattern6 }, {7, MaskPattern.Pattern7 }, {8, MaskPattern.Pattern8 }
+                public static readonly List<Func<int, int, bool>> Patterns =
+                    new List<Func<int, int, bool>>(8) {
+                        MaskPattern.Pattern1, MaskPattern.Pattern2, MaskPattern.Pattern3, MaskPattern.Pattern4,
+                        MaskPattern.Pattern5, MaskPattern.Pattern6, MaskPattern.Pattern7, MaskPattern.Pattern8
                     };
 
                 /// <summary>

--- a/QRCoder/QRCodeGenerator.ModulePlacer.cs
+++ b/QRCoder/QRCodeGenerator.ModulePlacer.cs
@@ -168,20 +168,21 @@ namespace QRCoder
                 }
 
                 // Apply the best mask pattern to the actual QR code.
+                var selectedPatternFunc = MaskPattern.Patterns[selectedPattern.Value];
                 for (var x = 0; x < size; x++)
                 {
                     for (var y = 0; y < x; y++)
                     {
                         if (!IsBlocked(new Rectangle(x, y, 1, 1), blockedModules))
                         {
-                            qrCode.ModuleMatrix[y][x] ^= MaskPattern.Patterns[selectedPattern.Value](x, y);
-                            qrCode.ModuleMatrix[x][y] ^= MaskPattern.Patterns[selectedPattern.Value](y, x);
+                            qrCode.ModuleMatrix[y][x] ^= selectedPatternFunc(x, y);
+                            qrCode.ModuleMatrix[x][y] ^= selectedPatternFunc(y, x);
                         }
                     }
 
                     if (!IsBlocked(new Rectangle(x, x, 1, 1), blockedModules))
                     {
-                        qrCode.ModuleMatrix[x][x] ^= MaskPattern.Patterns[selectedPattern.Value](x, x);
+                        qrCode.ModuleMatrix[x][x] ^= selectedPatternFunc(x, x);
                     }
                 }
                 return selectedPattern.Value;

--- a/QRCoder/QRCodeGenerator.ModulePlacer.cs
+++ b/QRCoder/QRCodeGenerator.ModulePlacer.cs
@@ -115,8 +115,10 @@ namespace QRCoder
 
                 // Temporary QRCodeData object to test different mask patterns without altering the original.
                 var qrTemp = new QRCodeData(version);
-                foreach (var pattern in MaskPattern.Patterns)
+                for (var maskPattern = 0; maskPattern < 8; maskPattern++)
                 {
+                    var patternFunc = MaskPattern.Patterns[maskPattern];
+
                     // Reset the temporary QR code to the current state of the actual QR code.
                     for (var y = 0; y < size; y++)
                     {
@@ -127,7 +129,7 @@ namespace QRCoder
                     }
 
                     // Place format information using the current mask pattern.
-                    var formatStr = GetFormatString(eccLevel, pattern.Key - 1);
+                    var formatStr = GetFormatString(eccLevel, maskPattern);
                     ModulePlacer.PlaceFormat(qrTemp, formatStr);
 
                     // Place version information if applicable.
@@ -144,14 +146,14 @@ namespace QRCoder
                         {
                             if (!IsBlocked(new Rectangle(x, y, 1, 1), blockedModules))
                             {
-                                qrTemp.ModuleMatrix[y][x] ^= pattern.Value(x, y);
-                                qrTemp.ModuleMatrix[x][y] ^= pattern.Value(y, x);
+                                qrTemp.ModuleMatrix[y][x] ^= patternFunc(x, y);
+                                qrTemp.ModuleMatrix[x][y] ^= patternFunc(y, x);
                             }
                         }
 
                         if (!IsBlocked(new Rectangle(x, x, 1, 1), blockedModules))
                         {
-                            qrTemp.ModuleMatrix[x][x] ^= pattern.Value(x, x);
+                            qrTemp.ModuleMatrix[x][x] ^= patternFunc(x, x);
                         }
                     }
 
@@ -160,7 +162,7 @@ namespace QRCoder
                     // Select the pattern with the lowest score, indicating better QR code readability.
                     if (!selectedPattern.HasValue || patternScore > score)
                     {
-                        selectedPattern = pattern.Key;
+                        selectedPattern = maskPattern;
                         patternScore = score;
                     }
                 }
@@ -182,7 +184,7 @@ namespace QRCoder
                         qrCode.ModuleMatrix[x][x] ^= MaskPattern.Patterns[selectedPattern.Value](x, x);
                     }
                 }
-                return selectedPattern.Value - 1;
+                return selectedPattern.Value;
             }
 
             /// <summary>

--- a/QRCoder/QRCodeGenerator.ModulePlacer.cs
+++ b/QRCoder/QRCodeGenerator.ModulePlacer.cs
@@ -107,8 +107,8 @@ namespace QRCoder
             /// <returns>The index of the selected mask pattern.</returns>
             public static int MaskCode(QRCodeData qrCode, int version, BlockedModules blockedModules, ECCLevel eccLevel)
             {
-                int? selectedPattern = null;
-                var patternScore = 0;
+                int selectedPattern = -1;        // no pattern selected yet
+                var patternScore = int.MaxValue; // lower score is better
 
                 var size = qrCode.ModuleMatrix.Count - 8;
 
@@ -165,7 +165,7 @@ namespace QRCoder
                     var score = MaskPattern.Score(qrTemp);
 
                     // Select the pattern with the lowest score, indicating better QR code readability.
-                    if (!selectedPattern.HasValue || patternScore > score)
+                    if (patternScore > score)
                     {
                         selectedPattern = maskPattern;
                         patternScore = score;
@@ -173,7 +173,7 @@ namespace QRCoder
                 }
 
                 // Apply the best mask pattern to the actual QR code.
-                var selectedPatternFunc = MaskPattern.Patterns[selectedPattern.Value];
+                var selectedPatternFunc = MaskPattern.Patterns[selectedPattern];
                 for (var x = 0; x < size; x++)
                 {
                     for (var y = 0; y < x; y++)
@@ -191,7 +191,7 @@ namespace QRCoder
                     }
                 }
 
-                return selectedPattern.Value;
+                return selectedPattern;
             }
 
             /// <summary>


### PR DESCRIPTION
This code changes `MaskPattern.Patterns` to a list instead of a dictionary to hopefully make some code easier to understand.

### Existing code

The index is stored zero-based within the QR code, and I was confused by this code here:

https://github.com/codebude/QRCoder/blob/14a83f2e1c2d946e54db72cd91f3e420630e1f71/QRCoder/QRCodeGenerator.ModulePlacer.cs#L130

followed by

https://github.com/codebude/QRCoder/blob/14a83f2e1c2d946e54db72cd91f3e420630e1f71/QRCoder/QRCodeGenerator.ModulePlacer.cs#L163

and 

https://github.com/codebude/QRCoder/blob/14a83f2e1c2d946e54db72cd91f3e420630e1f71/QRCoder/QRCodeGenerator.ModulePlacer.cs#L175-L176

which is actually correct because of 

https://github.com/codebude/QRCoder/blob/14a83f2e1c2d946e54db72cd91f3e420630e1f71/QRCoder/QRCodeGenerator.ModulePlacer.cs#L185

So since the dictionary is unnecessary, I converted it to a list.  It should be faster too but I didn't check.

### New code

Now we start with this:

https://github.com/codebude/QRCoder/blob/d48a2fb2d2b95fce2cdd35dfacdff68544e60c61/QRCoder/QRCodeGenerator.ModulePlacer.cs#L118-L120

and uses are simple:

https://github.com/codebude/QRCoder/blob/d48a2fb2d2b95fce2cdd35dfacdff68544e60c61/QRCoder/QRCodeGenerator.ModulePlacer.cs#L132

https://github.com/codebude/QRCoder/blob/d48a2fb2d2b95fce2cdd35dfacdff68544e60c61/QRCoder/QRCodeGenerator.ModulePlacer.cs#L165

https://github.com/codebude/QRCoder/blob/d48a2fb2d2b95fce2cdd35dfacdff68544e60c61/QRCoder/QRCodeGenerator.ModulePlacer.cs#L187