### PR TITLE
Implemented encoding constraints in SwissQRCode and GiroCode payloads

### DIFF
--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -711,6 +711,9 @@ namespace QRCoder
             private readonly Reference reference;
             private readonly AdditionalInformation additionalInformation;
 
+            public override QRCodeGenerator.ECCLevel EccLevel { get { return QRCodeGenerator.ECCLevel.M; } }
+            public override QRCodeGenerator.EciMode EciMode { get { return QRCodeGenerator.EciMode.Utf8; } }
+
             /// <summary>
             /// Generates the payload for a SwissQrCode v2.0. (Don't forget to use ECC-Level=M, EncodingMode=UTF-8 and to set the Swiss flag icon to the final QR code.)
             /// </summary>
@@ -1198,6 +1201,7 @@ namespace QRCoder
             private readonly GirocodeEncoding encoding;
             private readonly TypeOfRemittance typeOfRemittance;
 
+            public override QRCodeGenerator.ECCLevel EccLevel { get { return QRCodeGenerator.ECCLevel.M; } }
 
             /// <summary>
             /// Generates the payload for a Girocode (QR-Code with credit transfer information).

--- a/QRCoderApiTests/net35+net40+net50+net50-windows+netstandard20/QRCoder.approved.txt
+++ b/QRCoderApiTests/net35+net40+net50+net50-windows+netstandard20/QRCoder.approved.txt
@@ -428,6 +428,7 @@ namespace QRCoder
         public class Girocode : QRCoder.PayloadGenerator.Payload
         {
             public Girocode(string iban, string bic, string name, decimal amount, string remittanceInformation = "", QRCoder.PayloadGenerator.Girocode.TypeOfRemittance typeOfRemittance = 1, string purposeOfCreditTransfer = "", string messageToGirocodeUser = "", QRCoder.PayloadGenerator.Girocode.GirocodeVersion version = 0, QRCoder.PayloadGenerator.Girocode.GirocodeEncoding encoding = 1) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
             public override string ToString() { }
             public enum GirocodeEncoding
             {
@@ -705,6 +706,8 @@ namespace QRCoder
         public class SwissQrCode : QRCoder.PayloadGenerator.Payload
         {
             public SwissQrCode(QRCoder.PayloadGenerator.SwissQrCode.Iban iban, QRCoder.PayloadGenerator.SwissQrCode.Currency currency, QRCoder.PayloadGenerator.SwissQrCode.Contact creditor, QRCoder.PayloadGenerator.SwissQrCode.Reference reference, QRCoder.PayloadGenerator.SwissQrCode.AdditionalInformation additionalInformation = null, QRCoder.PayloadGenerator.SwissQrCode.Contact debitor = null, decimal? amount = default, System.DateTime? requestedDateOfPayment = default, QRCoder.PayloadGenerator.SwissQrCode.Contact ultimateCreditor = null, string alternativeProcedure1 = null, string alternativeProcedure2 = null) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
+            public override QRCoder.QRCodeGenerator.EciMode EciMode { get; }
             public override string ToString() { }
             public class AdditionalInformation
             {

--- a/QRCoderApiTests/net60-windows/QRCoder.approved.txt
+++ b/QRCoderApiTests/net60-windows/QRCoder.approved.txt
@@ -433,6 +433,7 @@ namespace QRCoder
         public class Girocode : QRCoder.PayloadGenerator.Payload
         {
             public Girocode(string iban, string bic, string name, decimal amount, string remittanceInformation = "", QRCoder.PayloadGenerator.Girocode.TypeOfRemittance typeOfRemittance = 1, string purposeOfCreditTransfer = "", string messageToGirocodeUser = "", QRCoder.PayloadGenerator.Girocode.GirocodeVersion version = 0, QRCoder.PayloadGenerator.Girocode.GirocodeEncoding encoding = 1) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
             public override string ToString() { }
             public enum GirocodeEncoding
             {
@@ -710,6 +711,8 @@ namespace QRCoder
         public class SwissQrCode : QRCoder.PayloadGenerator.Payload
         {
             public SwissQrCode(QRCoder.PayloadGenerator.SwissQrCode.Iban iban, QRCoder.PayloadGenerator.SwissQrCode.Currency currency, QRCoder.PayloadGenerator.SwissQrCode.Contact creditor, QRCoder.PayloadGenerator.SwissQrCode.Reference reference, QRCoder.PayloadGenerator.SwissQrCode.AdditionalInformation additionalInformation = null, QRCoder.PayloadGenerator.SwissQrCode.Contact debitor = null, decimal? amount = default, System.DateTime? requestedDateOfPayment = default, QRCoder.PayloadGenerator.SwissQrCode.Contact ultimateCreditor = null, string alternativeProcedure1 = null, string alternativeProcedure2 = null) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
+            public override QRCoder.QRCodeGenerator.EciMode EciMode { get; }
             public override string ToString() { }
             public class AdditionalInformation
             {

--- a/QRCoderApiTests/net60/QRCoder.approved.txt
+++ b/QRCoderApiTests/net60/QRCoder.approved.txt
@@ -391,6 +391,7 @@ namespace QRCoder
         public class Girocode : QRCoder.PayloadGenerator.Payload
         {
             public Girocode(string iban, string bic, string name, decimal amount, string remittanceInformation = "", QRCoder.PayloadGenerator.Girocode.TypeOfRemittance typeOfRemittance = 1, string purposeOfCreditTransfer = "", string messageToGirocodeUser = "", QRCoder.PayloadGenerator.Girocode.GirocodeVersion version = 0, QRCoder.PayloadGenerator.Girocode.GirocodeEncoding encoding = 1) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
             public override string ToString() { }
             public enum GirocodeEncoding
             {
@@ -668,6 +669,8 @@ namespace QRCoder
         public class SwissQrCode : QRCoder.PayloadGenerator.Payload
         {
             public SwissQrCode(QRCoder.PayloadGenerator.SwissQrCode.Iban iban, QRCoder.PayloadGenerator.SwissQrCode.Currency currency, QRCoder.PayloadGenerator.SwissQrCode.Contact creditor, QRCoder.PayloadGenerator.SwissQrCode.Reference reference, QRCoder.PayloadGenerator.SwissQrCode.AdditionalInformation additionalInformation = null, QRCoder.PayloadGenerator.SwissQrCode.Contact debitor = null, decimal? amount = default, System.DateTime? requestedDateOfPayment = default, QRCoder.PayloadGenerator.SwissQrCode.Contact ultimateCreditor = null, string alternativeProcedure1 = null, string alternativeProcedure2 = null) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
+            public override QRCoder.QRCodeGenerator.EciMode EciMode { get; }
             public override string ToString() { }
             public class AdditionalInformation
             {

--- a/QRCoderApiTests/netstandard13/QRCoder.approved.txt
+++ b/QRCoderApiTests/netstandard13/QRCoder.approved.txt
@@ -371,6 +371,7 @@ namespace QRCoder
         public class Girocode : QRCoder.PayloadGenerator.Payload
         {
             public Girocode(string iban, string bic, string name, decimal amount, string remittanceInformation = "", QRCoder.PayloadGenerator.Girocode.TypeOfRemittance typeOfRemittance = 1, string purposeOfCreditTransfer = "", string messageToGirocodeUser = "", QRCoder.PayloadGenerator.Girocode.GirocodeVersion version = 0, QRCoder.PayloadGenerator.Girocode.GirocodeEncoding encoding = 1) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
             public override string ToString() { }
             public enum GirocodeEncoding
             {
@@ -648,6 +649,8 @@ namespace QRCoder
         public class SwissQrCode : QRCoder.PayloadGenerator.Payload
         {
             public SwissQrCode(QRCoder.PayloadGenerator.SwissQrCode.Iban iban, QRCoder.PayloadGenerator.SwissQrCode.Currency currency, QRCoder.PayloadGenerator.SwissQrCode.Contact creditor, QRCoder.PayloadGenerator.SwissQrCode.Reference reference, QRCoder.PayloadGenerator.SwissQrCode.AdditionalInformation additionalInformation = null, QRCoder.PayloadGenerator.SwissQrCode.Contact debitor = null, decimal? amount = default, System.DateTime? requestedDateOfPayment = default, QRCoder.PayloadGenerator.SwissQrCode.Contact ultimateCreditor = null, string alternativeProcedure1 = null, string alternativeProcedure2 = null) { }
+            public override QRCoder.QRCodeGenerator.ECCLevel EccLevel { get; }
+            public override QRCoder.QRCodeGenerator.EciMode EciMode { get; }
             public override string ToString() { }
             public class AdditionalInformation
             {

--- a/QRCoderTests/PayloadGeneratorTests.cs
+++ b/QRCoderTests/PayloadGeneratorTests.cs
@@ -9,6 +9,7 @@ using static QRCoder.PayloadGenerator.BezahlCode;
 using static QRCoder.PayloadGenerator.SwissQrCode.Reference;
 using System.Reflection;
 using static QRCoder.PayloadGenerator.SwissQrCode.AdditionalInformation;
+using static QRCoder.QRCodeGenerator;
 
 namespace QRCoderTests
 {
@@ -1335,6 +1336,21 @@ namespace QRCoderTests
             exception.Message.ShouldBe("Message to the Girocode-User reader texts have to shorter than 71 chars.");
         }
 
+        [Fact]
+        [Category("PayloadGenerator/Girocode")]
+        public void girocode_generator_sets_encoding_parameters()
+        {
+            var iban = "DE33100205000001194700";
+            var bic = "BFSWDE33BER";
+            var name = "Wikimedia Fördergesellschaft";
+            var amount = 10.00m;
+
+            var payload = new PayloadGenerator.Girocode(iban, bic, name, amount);
+
+            payload.EccLevel.ShouldBe<ECCLevel>(ECCLevel.M);
+            payload.EciMode.ShouldBe<EciMode>(EciMode.Default);
+            payload.Version.ShouldBe(-1);
+        }
 
         [Fact]
         [Category("PayloadGenerator/BezahlCode")]
@@ -2567,6 +2583,21 @@ namespace QRCoderTests
                 .ShouldBe("SPC\r\n0200\r\n1\r\nCH2430043000000789012\r\nS\r\nJohn Doe\r\nParlamentsgebäude\r\n1\r\n3003\r\nBern\r\nCH\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n100.25\r\nCHF\r\nS\r\nJohn Doe\r\nParlamentsgebäude\r\n1\r\n3003\r\nBern\r\nCH\r\nQRR\r\n990005000000000320071012303\r\nThis is my unstructured message.\r\nEPD\r\nSome bill information here...");
         }
 
+        [Fact]
+        [Category("PayloadGenerator/SwissQrCode")]
+        public void swissqrcode_generator_sets_encoding_parameters()
+        {
+            var creditor = PayloadGenerator.SwissQrCode.Contact.WithStructuredAddress("John Doe", "3003", "Bern", "CH", "Parlamentsgebäude", "1");
+            var iban = new PayloadGenerator.SwissQrCode.Iban("CH2430043000000789012", PayloadGenerator.SwissQrCode.Iban.IbanType.QrIban);
+            var reference = new PayloadGenerator.SwissQrCode.Reference(ReferenceType.QRR, "990005000000000320071012303", ReferenceTextType.QrReference);
+            var currency = PayloadGenerator.SwissQrCode.Currency.EUR;
+
+            var payload = new PayloadGenerator.SwissQrCode(iban, currency, creditor, reference);
+
+            payload.EccLevel.ShouldBe<ECCLevel>(ECCLevel.M);
+            payload.EciMode.ShouldBe<EciMode>(EciMode.Utf8);
+            payload.Version.ShouldBe(-1);
+        }
 
         [Fact]
         [Category("PayloadGenerator/SwissQrCode")]


### PR DESCRIPTION
## Summary

If a payload type needs a specific eci mode/ecc level/version it should override the respecting parameters in the PayloadGenerator base class. Thus users don't have to set these values manually. Unfortunately some payload generators weren't updated after this feature (encoding parameters via payload) was added. This PR brings in the necessary changes/constraints.

This PR fixes/implements the following **bugs/features**:

* [x] Added EccLevel and EciMode constraints in SwissQRCode payload generator
* [x] Added EccLevel constraint in Girocode payload generator

## Test plan
PR contains test cases.

## Closing issues
<!-- Put `closes #XXXX` (XXXX=issue number) in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #525 
