### PR TITLE
Make QRCoder trimmable and add trimming tests

### DIFF
--- a/.github/workflows/wf-build-test.yml
+++ b/.github/workflows/wf-build-test.yml
@@ -86,7 +86,11 @@ jobs:
     - name: Run test .NET 6.0 Windows
       working-directory: QRCoderTests
       run: dotnet test -c Release -f net6.0-windows --nologo --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover
-    
+
+    - name: Run trim analysis
+      working-directory: QRCoderTrimAnalysis
+      run: dotnet publish -c Release -o bin/publish
+
     - name: Run API approval tests
       working-directory: QRCoderApiTests
       run: dotnet test -c Release --nologo --no-build

--- a/QRCoder.sln
+++ b/QRCoder.sln
@@ -15,9 +15,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QRCoderTests", "QRCoderTest
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QRCoder.Xaml", "QRCoder.Xaml\QRCoder.Xaml.csproj", "{A7A7E073-2504-4BA2-A63B-87AC34174789}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QRCoderApiTests", "QRCoderApiTests\QRCoderApiTests.csproj", "{5FACE5F6-53C9-4B89-91D4-162677893574}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QRCoderApiTests", "QRCoderApiTests\QRCoderApiTests.csproj", "{5FACE5F6-53C9-4B89-91D4-162677893574}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QRCoderBenchmarks", "QRCoderBenchmarks\QRCoderBenchmarks.csproj", "{C33AB74A-2AB3-4BEA-A67F-EAB578E74E25}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QRCoderBenchmarks", "QRCoderBenchmarks\QRCoderBenchmarks.csproj", "{C33AB74A-2AB3-4BEA-A67F-EAB578E74E25}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QRCoderTrimAnalysis", "QRCoderTrimAnalysis\QRCoderTrimAnalysis.csproj", "{F046136A-7BEA-49F3-9415-70CE50AD533B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -155,6 +157,22 @@ Global
 		{C33AB74A-2AB3-4BEA-A67F-EAB578E74E25}.Release|x64.Build.0 = Release|Any CPU
 		{C33AB74A-2AB3-4BEA-A67F-EAB578E74E25}.Release|x86.ActiveCfg = Release|Any CPU
 		{C33AB74A-2AB3-4BEA-A67F-EAB578E74E25}.Release|x86.Build.0 = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|ARM.Build.0 = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|x64.Build.0 = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Debug|x86.Build.0 = Debug|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|ARM.ActiveCfg = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|ARM.Build.0 = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|x64.ActiveCfg = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|x64.Build.0 = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|x86.ActiveCfg = Release|Any CPU
+		{F046136A-7BEA-49F3-9415-70CE50AD533B}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/QRCoder/Extensions/StringValueAttribute.cs
+++ b/QRCoder/Extensions/StringValueAttribute.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Reflection;
 using System.Text;
@@ -9,6 +10,7 @@ namespace QRCoder.Extensions
     /// <summary>
     /// Used to represent a string value for a value in an enum
     /// </summary>
+    [Obsolete("This attribute will be removed in a future version of QRCoder.")]
     public class StringValueAttribute : Attribute
     {
 
@@ -31,6 +33,7 @@ namespace QRCoder.Extensions
         }        
     }
 
+    [Obsolete("This class will be removed in a future version of QRCoder.")]
     public static class CustomExtensions
     {
         /// <summary>
@@ -38,6 +41,9 @@ namespace QRCoder.Extensions
         /// </summary>
         /// <param name="value"></param>
         /// <returns></returns>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("This method uses reflection to examine the provided enum value.")]
+#endif
         public static string GetStringValue(this Enum value)
         {            
 #if NETSTANDARD1_3

--- a/QRCoder/PayloadGenerator.cs
+++ b/QRCoder/PayloadGenerator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Diagnostics.CodeAnalysis;
 #if NETSTANDARD1_3
 using System.Reflection;
 #endif
@@ -2477,14 +2478,12 @@ namespace QRCoder
 
             //base
             private CharacterSets characterSet;
-            private MandatoryFields mFields;
-            private OptionalFields oFields;
+            private readonly MandatoryFields mFields = new MandatoryFields();
+            private readonly OptionalFields oFields = new OptionalFields();
             private string separator = "|";
 
             private RussiaPaymentOrder()
             {
-                mFields = new MandatoryFields();
-                oFields = new OptionalFields();
             }
 
             /// <summary>
@@ -2596,7 +2595,7 @@ namespace QRCoder
             private List<string> GetOptionalFieldsAsList()
             {
 #if NETSTANDARD1_3
-                return oFields.GetType().GetRuntimeProperties()
+                return typeof(OptionalFields).GetRuntimeProperties()
                         .Where(field => field.GetValue(oFields) != null)
                         .Select(field => {
                             var objValue = field.GetValue(oFields, null);
@@ -2605,7 +2604,7 @@ namespace QRCoder
                         })
                         .ToList();
 #else
-                return oFields.GetType().GetProperties()
+                return typeof(OptionalFields).GetProperties()
                         .Where(field => field.GetValue(oFields, null) != null)
                         .Select(field => {
                             var objValue = field.GetValue(oFields, null);
@@ -2624,7 +2623,7 @@ namespace QRCoder
             private List<string> GetMandatoryFieldsAsList()
             {
 #if NETSTANDARD1_3
-                return mFields.GetType().GetRuntimeFields()
+                return typeof(MandatoryFields).GetRuntimeFields()
                         .Where(field => field.GetValue(mFields) != null)
                         .Select(field => {
                             var objValue = field.GetValue(mFields);
@@ -2633,7 +2632,7 @@ namespace QRCoder
                         })
                         .ToList();
 #else
-                return mFields.GetType().GetFields()
+                return typeof(MandatoryFields).GetFields()
                         .Where(field => field.GetValue(mFields) != null)
                         .Select(field => {
                             var objValue = field.GetValue(mFields);

--- a/QRCoder/QRCoder.csproj
+++ b/QRCoder/QRCoder.csproj
@@ -8,6 +8,7 @@
     <DefineConstants Condition="'$(TargetFramework)' == 'net6.0-windows'">$(DefineConstants);NET6_0_WINDOWS</DefineConstants>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
+	<IsTrimmable Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net6.0'))">true</IsTrimmable>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/QRCoder/SvgQRCode.cs
+++ b/QRCoder/SvgQRCode.cs
@@ -362,7 +362,7 @@ namespace QRCoder
             /// <returns></returns>
             public string GetDataUri()
             {
-                return $"data:{_mediaType.GetStringValue()};base64,{_logoData}";
+                return $"data:{GetMimeType(_mediaType)};base64,{_logoData}";
             }
 
             /// <summary>
@@ -388,11 +388,29 @@ namespace QRCoder
             /// </summary>
             public enum MediaType : int
             {
+#pragma warning disable CS0618 // Type or member is obsolete
                 [StringValue("image/png")]
-                PNG = 0, 
+#pragma warning restore CS0618 // Type or member is obsolete
+                PNG = 0,
+#pragma warning disable CS0618 // Type or member is obsolete
                 [StringValue("image/svg+xml")]
+#pragma warning restore CS0618 // Type or member is obsolete
                 SVG = 1
             }
+
+            private string GetMimeType(MediaType type)
+            {
+                switch (type)
+                {
+                    case MediaType.PNG:
+                        return "image/png";
+                    case MediaType.SVG:
+                        return "image/svg+xml";
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(type));
+                }
+            }
+                
         }
     }
 

--- a/QRCoderApiTests/net35+net40+net50+net50-windows+netstandard20/QRCoder.approved.txt
+++ b/QRCoderApiTests/net35+net40+net50+net50-windows+netstandard20/QRCoder.approved.txt
@@ -967,10 +967,12 @@ namespace QRCoder.Exceptions
 }
 namespace QRCoder.Extensions
 {
+    [System.Obsolete("This class will be removed in a future version of QRCoder.")]
     public static class CustomExtensions
     {
         public static string GetStringValue(this System.Enum value) { }
     }
+    [System.Obsolete("This attribute will be removed in a future version of QRCoder.")]
     public class StringValueAttribute : System.Attribute
     {
         public StringValueAttribute(string value) { }

--- a/QRCoderApiTests/net60-windows/QRCoder.approved.txt
+++ b/QRCoderApiTests/net60-windows/QRCoder.approved.txt
@@ -977,10 +977,13 @@ namespace QRCoder.Exceptions
 }
 namespace QRCoder.Extensions
 {
+    [System.Obsolete("This class will be removed in a future version of QRCoder.")]
     public static class CustomExtensions
     {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method uses reflection to examine the provided enum value.")]
         public static string GetStringValue(this System.Enum value) { }
     }
+    [System.Obsolete("This attribute will be removed in a future version of QRCoder.")]
     public class StringValueAttribute : System.Attribute
     {
         public StringValueAttribute(string value) { }

--- a/QRCoderApiTests/net60/QRCoder.approved.txt
+++ b/QRCoderApiTests/net60/QRCoder.approved.txt
@@ -904,10 +904,13 @@ namespace QRCoder.Exceptions
 }
 namespace QRCoder.Extensions
 {
+    [System.Obsolete("This class will be removed in a future version of QRCoder.")]
     public static class CustomExtensions
     {
+        [System.Diagnostics.CodeAnalysis.RequiresUnreferencedCode("This method uses reflection to examine the provided enum value.")]
         public static string GetStringValue(this System.Enum value) { }
     }
+    [System.Obsolete("This attribute will be removed in a future version of QRCoder.")]
     public class StringValueAttribute : System.Attribute
     {
         public StringValueAttribute(string value) { }

--- a/QRCoderApiTests/netstandard13/QRCoder.approved.txt
+++ b/QRCoderApiTests/netstandard13/QRCoder.approved.txt
@@ -831,10 +831,12 @@ namespace QRCoder.Exceptions
 }
 namespace QRCoder.Extensions
 {
+    [System.Obsolete("This class will be removed in a future version of QRCoder.")]
     public static class CustomExtensions
     {
         public static string GetStringValue(this System.Enum value) { }
     }
+    [System.Obsolete("This attribute will be removed in a future version of QRCoder.")]
     public class StringValueAttribute : System.Attribute
     {
         public StringValueAttribute(string value) { }

--- a/QRCoderTrimAnalysis/Program.cs
+++ b/QRCoderTrimAnalysis/Program.cs
@@ -1,0 +1,2 @@
+﻿// See https://aka.ms/new-console-template for more information
+Console.WriteLine("Hello, World!");

--- a/QRCoderTrimAnalysis/QRCoderTrimAnalysis.csproj
+++ b/QRCoderTrimAnalysis/QRCoderTrimAnalysis.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- This project, when published, verifies that QRCoder is trimmable; see below link for more details. -->
+  <!-- https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?pivots=dotnet-6-0 -->
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+	<PublishTrimmed>true</PublishTrimmed>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors><!-- Ensure that trim warnings cause the publish to fail -->
+	<IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QRCoder\QRCoder.csproj" />
+	<TrimmerRootAssembly Include="QRCoder" />
+  </ItemGroup>
+
+</Project>

--- a/QRCoderTrimAnalysis/QRCoderTrimAnalysis.csproj
+++ b/QRCoderTrimAnalysis/QRCoderTrimAnalysis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <!-- This project, when published, verifies that QRCoder is trimmable; see below link for more details. -->
-  <!-- https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming?pivots=dotnet-6-0 -->
+  <!-- https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming -->
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
## Summary

This marks the QRCoder project as trimmable and fixes existing trim warnings within the project.

## Changes / notes

1. The RussianPaymentOrder payload generator uses reflection to add all properties to a list.  Users cannot provide their own derived class, so the property list is known.  As such, reflection is not even necessary.  However, by simply referencing the exact type in the code, trimming analysis will know to preserve all the relevant fields.
2. The SVG generator uses reflection to pull an associated string value (mime type) from an enum.  Similar to above, the type of the enum examined is always known and cannot change, so reflection is unnecessary.  In this instance I changed the code to use a switch case to return the proper mime type, eliminating the use of reflection.  The code that used reflection was publicly accessible and remains (marked as obsolete) to maintain binary backwards compatibility.  It is quite unlikely any users ever referenced these members, of course.

## Test plan

Pursuant to MS docs, a new project has been added, that when published, performs trim analysis on QRCoder.  Trim analysis has been configured to fail the publish.  CI has been configured to 'publish' this upon running the tests.

## Closing issues

Closes #537 