### PR TITLE
Remove framework overrides

### DIFF
--- a/QRCoder.Xaml/QRCoder.Xaml.csproj
+++ b/QRCoder.Xaml/QRCoder.Xaml.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net35;net40;net5.0-windows;net6.0-windows</TargetFrameworks>
@@ -48,8 +48,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-    <AutomaticallyUseReferenceAssemblyPackages Condition=" '$(TargetFramework)' == 'net35' ">false</AutomaticallyUseReferenceAssemblyPackages>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>QRCoder.XamlStrongName.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/QRCoder/QRCoder.csproj
+++ b/QRCoder/QRCoder.csproj
@@ -56,8 +56,6 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-    <AutomaticallyUseReferenceAssemblyPackages Condition=" '$(TargetFramework)' == 'net35' ">false</AutomaticallyUseReferenceAssemblyPackages>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>QRCoderStrongName.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/QRCoderTests/QRCoderTests.csproj
+++ b/QRCoderTests/QRCoderTests.csproj
@@ -62,8 +62,4 @@
 	    <CopyToOutputDirectory>Always</CopyToOutputDirectory>
 	  </None>
 	</ItemGroup>
-	<PropertyGroup>
-		<FrameworkPathOverride Condition="'$(TargetFramework)' == 'net35'">$(MSBuildProgramFiles32)\Reference Assemblies\Microsoft\Framework\.NETFramework\v3.5\Profile\Client</FrameworkPathOverride>
-		<AutomaticallyUseReferenceAssemblyPackages Condition=" '$(TargetFramework)' == 'net35' ">false</AutomaticallyUseReferenceAssemblyPackages>
-	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## Summary

The QRCoder solution won't build on my Windows 11 laptop with a fresh installation of Visual Studio 2022, even with the .NET Framework 3.5 development tools installed.  It seems to be related to the framework override csproj properties.  It builds fine when I remove them.

Can we remove these properties?

## Test plan
Ensure it builds without these excess properties, both locally and in CI.
