### PR TITLE
BitmapByteQRCode performance optimization

### DIFF
--- a/QRCoder/BitmapByteQRCode.cs
+++ b/QRCoder/BitmapByteQRCode.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using static QRCoder.QRCodeGenerator;
 
 namespace QRCoder;

--- a/QRCoder/BitmapByteQRCode.cs
+++ b/QRCoder/BitmapByteQRCode.cs
@@ -113,7 +113,7 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
                 bmp.AddRange(padding);
             }
         }
-        
+
         return bmp.ToArray();
     }
 

--- a/QRCoder/BitmapByteQRCode.cs
+++ b/QRCoder/BitmapByteQRCode.cs
@@ -83,7 +83,7 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
         ix += _bitmapHeaderPart1.Length;
 
         // Filesize
-        CopyIntAs4ByteToArray(fileSize, ix, ref bmp);
+        CopyIntAs4ByteToArray(fileSize, ix, bmp);
         ix += 4;
 
         // Header part 2
@@ -91,10 +91,10 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
         ix += _bitmapHeaderPart2.Length;
 
         // Width
-        CopyIntAs4ByteToArray(sideLength, ix, ref bmp);
+        CopyIntAs4ByteToArray(sideLength, ix, bmp);
         ix += 4;
         // Height
-        CopyIntAs4ByteToArray(sideLength, ix, ref bmp);
+        CopyIntAs4ByteToArray(sideLength, ix, bmp);
         ix += 4;
 
         // Header end
@@ -106,7 +106,6 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
 
 
         // Draw qr code
-        var group = new byte[(int)(sideLength / pixelsPerModule) * moduleDark.Length];
         for (var x = sideLength - 1; x >= 0; x -= pixelsPerModule)
         {
             var modMatrixX = (x + pixelsPerModule) / pixelsPerModule - 1;
@@ -116,7 +115,6 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
             for (var y = 0; y < sideLength; y += pixelsPerModule)
             {
                 var module = QrCodeData.ModuleMatrix[modMatrixX][(y + pixelsPerModule) / pixelsPerModule - 1];
-                Array.Copy(module ? moduleDark : moduleLight, 0, group, y / pixelsPerModule * moduleDark.Length, moduleDark.Length);
                 Array.Copy(module ? moduleDark : moduleLight, 0, bmp, ix, moduleDark.Length);
                 ix += moduleDark.Length;
             }
@@ -159,7 +157,7 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
     /// <param name="inp">The integer to convert.</param>
     /// <param name="destinationIndex">Index of destinationArray where the converted bytes are written to</param>
     /// <param name="destinationArray">Destination byte array that receives the bytes</param>
-    private void CopyIntAs4ByteToArray(int inp, int destinationIndex, ref byte[] destinationArray)
+    private void CopyIntAs4ByteToArray(int inp, int destinationIndex, byte[] destinationArray)
     {
         unchecked
         {

--- a/QRCoderBenchmarks/BitmapByteQRCode.cs
+++ b/QRCoderBenchmarks/BitmapByteQRCode.cs
@@ -1,0 +1,51 @@
+using System.Collections.ObjectModel;
+using BenchmarkDotNet.Attributes;
+using QRCoder;
+
+namespace QRCoderBenchmarks;
+
+[MemoryDiagnoser]
+public class BitmapByteQRCodeBenchmark
+{
+    private readonly Dictionary<string, QRCodeData> _samples;
+
+    public BitmapByteQRCodeBenchmark()
+    {
+        var eccLvl = QRCoder.QRCodeGenerator.ECCLevel.L;
+        _samples = new Dictionary<string, QRCodeData>()
+        {
+            { "small", QRCoder.QRCodeGenerator.GenerateQrCode("ABCD", eccLvl) },
+            { "medium", QRCoder.QRCodeGenerator.GenerateQrCode("https://github.com/codebude/QRCoder/blob/f89aa90081f369983a9ba114e49cc6ebf0b2a7b1/QRCoder/Framework4.0Methods/Stream4Methods.cs", eccLvl) },
+            { "big", QRCoder.QRCodeGenerator.GenerateQrCode( new string('a', 2600), eccLvl) }
+        };
+    }
+
+
+    [Benchmark]
+    public void RenderBitmapByteQRCodeSmall()
+    {
+        var qrCode = new BitmapByteQRCode(_samples["small"]);
+        _ = qrCode.GetGraphic(10);
+    }
+
+    [Benchmark]
+    public void RenderBitmapByteQRCodeMedium()
+    {
+        var qrCode = new BitmapByteQRCode(_samples["medium"]);
+        _ = qrCode.GetGraphic(10);
+    }
+
+    [Benchmark]
+    public void RenderBitmapByteQRCodeBig()
+    {
+        var qrCode = new BitmapByteQRCode(_samples["big"]);
+        _ = qrCode.GetGraphic(10);
+    }
+
+    [Benchmark]
+    public void RenderBitmapByteQRCodeHuge()
+    {
+        var qrCode = new BitmapByteQRCode(_samples["big"]);
+        _ = qrCode.GetGraphic(50);
+    }
+}

--- a/QRCoderBenchmarks/BitmapByteQRCode.cs
+++ b/QRCoderBenchmarks/BitmapByteQRCode.cs
@@ -1,4 +1,3 @@
-using System.Collections.ObjectModel;
 using BenchmarkDotNet.Attributes;
 using QRCoder;
 

--- a/QRCoderTests/BitmapByteQRCodeRendererTests.cs
+++ b/QRCoderTests/BitmapByteQRCodeRendererTests.cs
@@ -1,0 +1,50 @@
+using QRCoder;
+using QRCoderTests.Helpers;
+using QRCoderTests.Helpers.XUnitExtenstions;
+using Shouldly;
+using Xunit;
+
+
+namespace QRCoderTests;
+
+
+public class BitmapByteQRCodeRendererTests
+{
+    [Fact]
+    [Category("QRRenderer/BitmapByteQRCode")]
+    public void can_render_bitmapbyte_qrcode()
+    {
+        var gen = new QRCodeGenerator();
+        var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.H);
+        var bmp = new BitmapByteQRCode(data).GetGraphic(10);
+
+        var result = HelperFunctions.ByteArrayToHash(bmp);
+        result.ShouldBe("2d262d074f5c436ad93025150392dd38");
+    }
+
+
+    [Fact]
+    [Category("QRRenderer/BitmapByteQRCode")]
+    public void can_render_bitmapbyte_qrcode_color_bytearray()
+    {
+        var gen = new QRCodeGenerator();
+        var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.H);
+        var bmp = new BitmapByteQRCode(data).GetGraphic(10, new byte[] { 30, 30, 30 }, new byte[] { 255, 0, 0 });
+
+        var result = HelperFunctions.ByteArrayToHash(bmp);
+        result.ShouldBe("1184507c7eb98f9ca76afd04313c41cb");
+    }
+
+    [Fact]
+    [Category("QRRenderer/BitmapByteQRCode")]
+    public void can_render_bitmapbyte_qrcode_drawing_color()
+    {
+        var gen = new QRCodeGenerator();
+        var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.H);
+        var bmp = new BitmapByteQRCode(data).GetGraphic(10, "#e3e3e3", "#ffffff");
+
+        var result = HelperFunctions.ByteArrayToHash(bmp);
+        result.ShouldBe("40cd208fc46aa726d6e98a2028ffd2b7");
+    }
+
+}


### PR DESCRIPTION
## Summary
I tried to optimize the performance of BitmapByteQRCode by removing loops and pre-calculating data where possible. Also fixed object size/capacity to keep memory footprint low. 

## Performance details

**Before this PR**
| Method                       | Mean         | Error      | StdDev     | Gen0        | Gen1      | Gen2      | Allocated  |
|----------------------------- |-------------:|-----------:|-----------:|------------:|----------:|----------:|-----------:|
| RenderBitmapByteQRCodeSmall  |     2.369 ms |  0.0457 ms |  0.0489 ms |    496.0938 |  210.9375 |  210.9375 |    7.22 MB |
| RenderBitmapByteQRCodeMedium |     7.903 ms |  0.1557 ms |  0.1456 ms |   1734.3750 |  750.0000 |  750.0000 |   21.26 MB |
| RenderBitmapByteQRCodeBig    |    89.976 ms |  1.0133 ms |  0.8983 ms |  18000.0000 | 2166.6667 | 2166.6667 |  265.99 MB |
| RenderBitmapByteQRCodeHuge   | 2,090.730 ms | 33.4541 ms | 31.2930 ms | 407000.0000 | 8000.0000 | 8000.0000 | 6775.64 MB |

**After/with changes from this PR**
| Method                       | Mean        | Error       | StdDev      | Gen0      | Gen1      | Gen2      | Allocated   |
|----------------------------- |------------:|------------:|------------:|----------:|----------:|----------:|------------:|
| RenderBitmapByteQRCodeSmall  |    115.1 us |     2.29 us |     4.83 us |  153.8086 |  153.8086 |  153.8086 |   495.75 KB |
| RenderBitmapByteQRCodeMedium |    163.1 us |     3.16 us |     4.11 us |  299.0723 |  298.8281 |  298.8281 |  1412.45 KB |
| RenderBitmapByteQRCodeBig    |  3,156.9 us |    62.66 us |    87.84 us |  988.2813 |  988.2813 |  988.2813 | 18372.12 KB |
| RenderBitmapByteQRCodeHuge   | 74,284.9 us | 1,432.76 us | 1,961.18 us | 1000.0000 | 1000.0000 | 1000.0000 | 458983.6 KB |


**After implementing changes suggested by @Shane32 via PR review**
| Method                       | Mean         | Error        | StdDev       | Gen0     | Gen1     | Gen2     | Allocated    |
|----------------------------- |-------------:|-------------:|-------------:|---------:|---------:|---------:|-------------:|
| RenderBitmapByteQRCodeSmall  |     73.79 us |     0.901 us |     0.799 us |  76.9043 |  76.9043 |  76.9043 |     247.3 KB |
| RenderBitmapByteQRCodeMedium |    208.30 us |     3.268 us |     2.897 us | 199.9512 | 199.9512 | 199.9512 |    704.85 KB |
| RenderBitmapByteQRCodeBig    |  1,162.20 us |    22.314 us |    25.697 us | 500.0000 | 500.0000 | 500.0000 |   9182.63 KB |
| RenderBitmapByteQRCodeHuge   | 57,819.92 us | 1,858.610 us | 5,450.982 us | 833.3333 | 833.3333 | 833.3333 | 229479.24 KB |

## Test plan
To ensure that the optimizations work out and break anything I added test cases and benchmarks to the project.
