### PR TITLE
Raised version counter to 1.6.1 for next release

### DIFF
--- a/QRCoder.Xaml/Properties/AssemblyInfo.cs
+++ b/QRCoder.Xaml/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/QRCoder.Xaml/QRCoder.Xaml.csproj
+++ b/QRCoder.Xaml/QRCoder.Xaml.csproj
@@ -17,7 +17,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>QRCoder.Xaml</PackageId>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Authors>Raffael Herrmann</Authors>
     <PackageOwners>Raffael Herrmann</PackageOwners>
     <AssemblyName>QRCoder.Xaml</AssemblyName>

--- a/QRCoder/Properties/AssemblyInfo.cs
+++ b/QRCoder/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.0.0")]
-[assembly: AssemblyFileVersion("1.6.0.0")]
+[assembly: AssemblyVersion("1.6.1.0")]
+[assembly: AssemblyFileVersion("1.6.1.0")]

--- a/QRCoder/QRCoder.csproj
+++ b/QRCoder/QRCoder.csproj
@@ -19,7 +19,7 @@
   <PropertyGroup>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageId>QRCoder</PackageId>
-    <Version>1.6.0</Version>
+    <Version>1.6.1</Version>
     <Authors>Raffael Herrmann</Authors>
     <PackageOwners>Raffael Herrmann</PackageOwners>
     <AssemblyName>QRCoder</AssemblyName>


### PR DESCRIPTION
As QRCoder 1.6.0 is release now, we raise the version counter to 1.6.1, so that ci builds get tagged as 1.6.1-ci...