### PR TITLE
Pin .NET SDK to 8.x for local/CI builds

### DIFF
--- a/QRCoder.sln
+++ b/QRCoder.sln
@@ -25,6 +25,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		global.json = global.json
 	EndProjectSection
 EndProject
 Global

--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "allowPrerelease": false,
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
Ensures that test runs are consistent whether or not the CI runner or local devs have the same SDK(s) installed