### PR TITLE
Reduced some allocations in `QRCodeGenerator` (NETCORE_APP only)

### DIFF
--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1061,6 +1061,17 @@ public partial class QRCodeGenerator : IDisposable
 #if NETCOREAPP
         static ReadOnlySpan<int> GetNotUniqueExponents(Polynom list, Span<int> buffer)
         {
+            // It works as follows:
+            // 1. a scratch buffer of the same size as the list is passed in
+            // 2. exponents are written / copied to that scratch buffer
+            // 3. scratch buffer is sorted, thus the exponents are in order
+            // 4. for each item in the scratch buffer (= ordered exponents) it's compared w/ the previous one
+            //   * if equal, then increment a counter
+            //   * else check if the counter is $>0$ and if so write the exponent to the result
+            // 
+            // For writing the result the same scratch buffer is used, as by definition the index to write the result 
+            // is `<=` the iteration index, so no overlap, etc. can occur.
+
             Debug.Assert(list.Count == buffer.Length);
 
             int idx = 0;

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1018,7 +1018,13 @@ public partial class QRCodeGenerator : IDisposable
 
         // Identify and merge terms with the same exponent.
         var toGlue = GetNotUniqueExponents(resultPolynom);
+#if NETCOREAPP
+        var gluedPolynoms = toGlue.Length <= 128
+            ? stackalloc PolynomItem[128].Slice(0, toGlue.Length)
+            : new PolynomItem[toGlue.Length];
+#else
         var gluedPolynoms = new PolynomItem[toGlue.Length];
+#endif
         var gluedPolynomsIndex = 0;
         foreach (var exponent in toGlue)
         {

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1042,7 +1042,7 @@ public partial class QRCodeGenerator : IDisposable
 
         // Remove duplicated exponents and add the corrected ones back.
         for (int i = resultPolynom.Count - 1; i >= 0; i--)
-            if (toGlue.Contains(resultPolynom[i].Exponent))
+            if (Array.IndexOf(toGlue, resultPolynom[i].Exponent) >= 0)
                 resultPolynom.RemoveAt(i);
         foreach (var polynom in gluedPolynoms)
             resultPolynom.Add(polynom);

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -224,15 +224,9 @@ public partial class QRCodeGenerator : IDisposable
         // Place interleaved data on module matrix
         var qrData = PlaceModules();
 
-#if NETCOREAPP
-        foreach (var codeWord in codeWordWithECC)
-        {
-            codeWord.Dispose();
-        }
-#endif
+        CodewordBlock.ReturnList(codeWordWithECC);
 
         return qrData;
-
 
         // fills the bit array with a repeating pattern to reach the required length
         void PadData()
@@ -268,7 +262,7 @@ public partial class QRCodeGenerator : IDisposable
             using (var generatorPolynom = CalculateGeneratorPolynom(eccInfo.ECCPerBlock))
             {
                 //Calculate error correction words
-                codewordBlocks = new List<CodewordBlock>(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2);
+                codewordBlocks = CodewordBlock.GetList(eccInfo.BlocksInGroup1 + eccInfo.BlocksInGroup2);
                 AddCodeWordBlocks(1, eccInfo.BlocksInGroup1, eccInfo.CodewordsInGroup1, 0, bitArray.Length, generatorPolynom);
                 int offset = eccInfo.BlocksInGroup1 * eccInfo.CodewordsInGroup1 * 8;
                 AddCodeWordBlocks(2, eccInfo.BlocksInGroup2, eccInfo.CodewordsInGroup2, offset, bitArray.Length - offset, generatorPolynom);

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -121,8 +121,14 @@ public partial class QRCodeGenerator : IDisposable
             //Version was passed as fixed version via parameter. Thus let's check if chosen version is valid.
             if (minVersion > version)
             {
-                var maxSizeByte = CapacityTables.GetVersionInfo(version).Details.First(x => x.ErrorCorrectionLevel == eccLevel).CapacityDict[encoding];
-                throw new QRCoder.Exceptions.DataTooLongException(eccLevel.ToString(), encoding.ToString(), version, maxSizeByte);
+                // Use a throw-helper to avoid allocating a closure
+                Throw(eccLevel, encoding, version);
+
+                static void Throw(ECCLevel eccLevel, EncodingMode encoding, int version)
+                {
+                    var maxSizeByte = CapacityTables.GetVersionInfo(version).Details.First(x => x.ErrorCorrectionLevel == eccLevel).CapacityDict[encoding];
+                    throw new Exceptions.DataTooLongException(eccLevel.ToString(), encoding.ToString(), version, maxSizeByte);
+                }
             }
         }
 

--- a/QRCoder/QRCodeGenerator/CapacityTables.cs
+++ b/QRCoder/QRCodeGenerator/CapacityTables.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -36,7 +37,17 @@ public partial class QRCodeGenerator
         /// block group details, and other parameters required for encoding error correction data.
         /// </returns>
         public static ECCInfo GetEccInfo(int version, ECCLevel eccLevel)
-            => _capacityECCTable.Single(x => x.Version == version && x.ErrorCorrectionLevel == eccLevel);
+        {
+            foreach (var item in _capacityECCTable)
+            {
+                if (item.Version == version && item.ErrorCorrectionLevel == eccLevel)
+                {
+                    return item;
+                }
+            }
+
+            throw new InvalidOperationException("No item found");   // same exception type as Linq would throw
+        }
 
         /// <summary>
         /// Retrieves the capacity information for a specific QR code version.
@@ -92,11 +103,19 @@ public partial class QRCodeGenerator
             }
 
             // if no version was found, throw an exception
-            var maxSizeByte = _capacityTable.Where(
-                x => x.Details.Any(
-                    y => (y.ErrorCorrectionLevel == eccLevel))
-                ).Max(x => x.Details.Single(y => y.ErrorCorrectionLevel == eccLevel).CapacityDict[encMode]);
-            throw new QRCoder.Exceptions.DataTooLongException(eccLevel.ToString(), encMode.ToString(), maxSizeByte);
+            // In order to get the maxSizeByte we use a throw-helper method to avoid the allocation of a closure
+            Throw(encMode, eccLevel);
+            throw null!;    // this is needed to make the compiler happy
+
+            static void Throw(EncodingMode encMode, ECCLevel eccLevel)
+            {
+                var maxSizeByte = _capacityTable.Where(
+                    x => x.Details.Any(
+                        y => (y.ErrorCorrectionLevel == eccLevel))
+                    ).Max(x => x.Details.Single(y => y.ErrorCorrectionLevel == eccLevel).CapacityDict[encMode]);
+
+                throw new Exceptions.DataTooLongException(eccLevel.ToString(), encMode.ToString(), maxSizeByte);
+            }
         }
 
         /// <summary>

--- a/QRCoder/QRCodeGenerator/CodewordBlock.cs
+++ b/QRCoder/QRCodeGenerator/CodewordBlock.cs
@@ -1,3 +1,9 @@
+using System;
+
+#if NETCOREAPP
+using System.Buffers;
+#endif
+
 namespace QRCoder;
 
 public partial class QRCodeGenerator
@@ -6,7 +12,10 @@ public partial class QRCodeGenerator
     /// Represents a block of codewords in a QR code. QR codes are divided into several blocks for error correction purposes.
     /// Each block contains a series of data codewords followed by error correction codewords.
     /// </summary>
-    private struct CodewordBlock
+    private readonly struct CodewordBlock
+#if NETCOREAPP
+        : IDisposable
+#endif
     {
         /// <summary>
         /// Initializes a new instance of the CodewordBlock struct with specified arrays of code words and error correction (ECC) words.
@@ -14,7 +23,7 @@ public partial class QRCodeGenerator
         /// <param name="codeWordsOffset">The offset of the data codewords within the main BitArray. Data codewords carry the actual information.</param>
         /// <param name="codeWordsLength">The length in bits of the data codewords within the main BitArray.</param>
         /// <param name="eccWords">The array of error correction codewords for this block. These codewords help recover the data if the QR code is damaged.</param>
-        public CodewordBlock(int codeWordsOffset, int codeWordsLength, byte[] eccWords)
+        public CodewordBlock(int codeWordsOffset, int codeWordsLength, ArraySegment<byte> eccWords)
         {
             CodeWordsOffset = codeWordsOffset;
             CodeWordsLength = codeWordsLength;
@@ -34,6 +43,10 @@ public partial class QRCodeGenerator
         /// <summary>
         /// Gets the error correction codewords associated with this block.
         /// </summary>
-        public byte[] ECCWords { get; }
+        public ArraySegment<byte> ECCWords { get; }
+
+#if NETCOREAPP
+        public void Dispose() => ArrayPool<byte>.Shared.Return(ECCWords.Array!);
+#endif
     }
 }

--- a/QRCoder/QRCodeGenerator/GaloisField.cs
+++ b/QRCoder/QRCodeGenerator/GaloisField.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 
 namespace QRCoder;
 
@@ -43,6 +44,9 @@ public partial class QRCodeGenerator
         /// This is particularly necessary when performing multiplications in the field which can result in exponents exceeding the field's maximum.
         /// </summary>
         public static int ShrinkAlphaExp(int alphaExp)
-            => (alphaExp % 256) + (alphaExp / 256);
+        {
+            Debug.Assert(alphaExp >= 0);
+            return (int)((uint)alphaExp % 256 + (uint)alphaExp / 256);
+        }
     }
 }


### PR DESCRIPTION
Profiling showed that there are some allocations in `QRCodeGenerator` that can be quite easily avoided.

<details>
  <summary>simple console app for profiling</summary>

```c#
using System.Diagnostics;
using QRCoder;

string payload = $"""
    Time    : {DateTimeOffset.Now:O}
    Machine : {Environment.MachineName}
    Activity: {Activity.Current?.RootId}
    """;

int len = 0;

for (int i = 0; i < 1_000; ++i)
{
    string imgSrc = GetQRCode("sdfsdf");
    len += imgSrc.Length;
}

Console.WriteLine(len);

static string GetQRCode(string payload)
{
    using QRCodeGenerator qrCodeGenerator = new();
    using QRCodeData qrCodeData = qrCodeGenerator.CreateQrCode(payload, QRCodeGenerator.ECCLevel.Q);
    using Base64QRCode qrCodeBase64 = new(qrCodeData);
    string base64QRCode = qrCodeBase64.GetGraphic(20);
    return $"data:image/png;base64,{base64QRCode}";
}
```
</details>

Allocations are removed / avoided for:
* `Dictionary<,>.Entry[]`
* `QRCodeGenerator.PolynomItem[]`
* `Dictionary<,>`

The change is done only for .NET (Core) targets, as `Span<T>` is used.
By adding a reference to System.Memory package this change could also be done for .NET Desktop.

## Profile

### Before

![before](https://github.com/user-attachments/assets/03dc03dc-b40c-4948-bd37-273572410f4a)

### After

![after](https://github.com/user-attachments/assets/6e29b89a-36b8-4e8e-aa0f-954b7a419399)


## Benchmarks

### Before

```
| Method              | Mean        | Error     | StdDev    | Gen0   | Allocated |
|-------------------- |------------:|----------:|----------:|-------:|----------:|
| CreateQRCode        |    235.2 μs |   4.50 μs |   5.00 μs | 2.1973 |    7.2 KB |
| CreateQRCodeLong    |  2,684.9 μs |  48.00 μs |  44.89 μs | 7.8125 |  33.25 KB |
| CreateQRCodeLongest | 16,264.4 μs | 317.90 μs | 485.47 μs |      - |  79.69 KB |
```

### After

```
| Method              | Mean        | Error     | StdDev    | Gen0   | Allocated |
|-------------------- |------------:|----------:|----------:|-------:|----------:|
| CreateQRCode        |    232.0 μs |   4.63 μs |   6.64 μs | 0.9766 |   4.38 KB |
| CreateQRCodeLong    |  2,574.1 μs |  41.97 μs |  39.26 μs | 3.9063 |     12 KB |
| CreateQRCodeLongest | 15,573.7 μs | 292.90 μs | 259.65 μs |      - |  48.24 KB |
```