### PR TITLE
Hide approval files in Solution Explorer

### DIFF
--- a/QRCoderTests/QRCoderTests.csproj
+++ b/QRCoderTests/QRCoderTests.csproj
@@ -54,4 +54,9 @@
     <EmbeddedResource Include="assets\noun_Scientist_2909361.svg" />
     <EmbeddedResource Include="assets\noun_software engineer_2909346.png" />
   </ItemGroup>
+  <ItemGroup>
+    <None Include="**\*.approved.*;**\*.received.*">
+      <DependentUpon>$([System.String]::Copy('%(Filename)').Split('.')[0]).cs</DependentUpon>
+    </None>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
Nests approval files underneath their corresponding class

<img width="568" height="286" alt="image" src="https://github.com/user-attachments/assets/34cf76a3-d393-4cf7-9fe3-f00c4a3a51a6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test project configuration to exclude verification artifacts from build and associate them with their corresponding test files for better organization in IDEs.

* **Chores**
  * Improved handling of non-source test files to reduce clutter and streamline project navigation.

No user-facing changes or behavioral modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->