### PR TITLE
Fix tests & code coverage reporting

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -27,8 +27,6 @@
     <PackageIcon>nuget-icon.png</PackageIcon>
 
     <!-- Set misc build properties -->
-    <Deterministic>true</Deterministic>
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <DebugType>embedded</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,7 +8,6 @@
 
   <!-- Strong name signing for Release builds of packable projects -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release' AND '$(IsPackable)' == 'true'">
-    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
   </PropertyGroup>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -8,8 +8,14 @@
 
   <!-- Strong name signing for Release builds of packable projects -->
   <PropertyGroup Condition="'$(Configuration)' == 'Release' AND '$(IsPackable)' == 'true'">
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
   </PropertyGroup>
-  
+
+  <!-- Normalize file paths for releases -->
+  <PropertyGroup>
+    <ContinuousIntegrationBuild Condition="'$(Configuration)' == 'Release' AND '$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
 </Project>


### PR DESCRIPTION
- Removed `Deterministic` because it defaults to `true`
- Removed `ContinuousIntegrationBuild` from `Debug` builds because normalization of filenames prevented `ShouldMatchApproved` from properly reading approval files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration so the continuous-integration build flag applies only to Release builds in CI, standardizing file paths in release artifacts for more consistent packages.
  * Removed the explicit deterministic build setting, aligning with default tooling behavior. As a result, artifact checksums may vary between separate builds, while end-users should see no functional changes in application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->