### PR TITLE
Add bash shell specification for package publishing steps in CI workflows

### DIFF
--- a/.github/workflows/wf-build-release-ci.yml
+++ b/.github/workflows/wf-build-release-ci.yml
@@ -91,4 +91,5 @@ jobs:
         path: out/*
 
     - name: Publish packages to Github packages
+      shell: bash
       run: dotnet nuget push "out/*" -k ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/wf-build-release.yml
+++ b/.github/workflows/wf-build-release.yml
@@ -48,6 +48,7 @@ jobs:
         path: out/*
 
     - name: Publish packages to Github packages
+      shell: bash
       run: dotnet nuget push "out/*" -k ${{secrets.NUGET_AUTH_TOKEN}}
 
     - name: Upload Nuget packages as release artifacts


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflows to explicitly use bash for the package publishing step, improving consistency and reliability of releases.
  * No user-facing functionality changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->