### PR TITLE
Fix path separator in NuGet push command for GitHub packages

### DIFF
--- a/.github/workflows/wf-build-release-ci.yml
+++ b/.github/workflows/wf-build-release-ci.yml
@@ -91,5 +91,4 @@ jobs:
         path: out/*
 
     - name: Publish packages to Github packages
-      shell: bash
-      run: dotnet nuget push "out/*" -k ${{secrets.GITHUB_TOKEN}}
+      run: dotnet nuget push "out\*" -k ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/wf-build-release.yml
+++ b/.github/workflows/wf-build-release.yml
@@ -48,8 +48,7 @@ jobs:
         path: out/*
 
     - name: Publish packages to Github packages
-      shell: bash
-      run: dotnet nuget push "out/*" -k ${{secrets.NUGET_AUTH_TOKEN}}
+      run: dotnet nuget push "out\*" -k ${{secrets.NUGET_AUTH_TOKEN}}
 
     - name: Upload Nuget packages as release artifacts
       uses: actions/github-script@v8


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release CI to use the default Windows shell on Windows runners and align path syntax for package publishing.
  * Simplified the publish step configuration in build and release pipelines to improve reliability and consistency.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->