### PR TITLE
Make Postscript renderer deterministic

### DIFF
--- a/QRCoder/PostscriptQRCode.cs
+++ b/QRCoder/PostscriptQRCode.cs
@@ -101,7 +101,7 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         var pointsPerModule = (double)Math.Min(viewBox.Width, viewBox.Height) / (double)drawableModulesCount;
 
         string psFile = string.Format(PS_HEADER, new object[] {
-            DateTime.Now.ToString("s"), CleanSvgVal(viewBox.Width), CleanSvgVal(pointsPerModule),
+            CleanSvgVal(viewBox.Width), CleanSvgVal(pointsPerModule),
             epsFormat ? "EPSF-3.0" : string.Empty
         });
         psFile += string.Format(PS_FUNCTIONS, new object[] {
@@ -130,68 +130,75 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
     /// <returns>Returns the cleaned string representation of the double value.</returns>
     private string CleanSvgVal(double input) => input.ToString(System.Globalization.CultureInfo.InvariantCulture);
 
-    private const string PS_HEADER = @"%!PS-Adobe-3.0 {3}
-%%Creator: QRCoder.NET
-%%Title: QRCode
-%%CreationDate: {0}
-%%DocumentData: Clean7Bit
-%%Origin: 0
-%%DocumentMedia: Default {1} {1} 0 () ()
-%%BoundingBox: 0 0 {1} {1}
-%%LanguageLevel: 2 
-%%Pages: 1
-%%Page: 1 1
-%%EndComments
-%%BeginConstants
-/sz {1} def
-/sc {2} def
-%%EndConstants
-%%BeginFeature: *PageSize Default
-<< /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
-%%EndFeature
-";
+    // Note: line terminations here will encode differently based on which platform QRCoder was compiled on (CRLF vs LF);
+    // however, PostScript interpreters should handle both equally well.
+    private const string PS_HEADER = """
+        %!PS-Adobe-3.0 {2}
+        %%Creator: QRCoder.NET
+        %%Title: QRCode
+        %%DocumentData: Clean7Bit
+        %%Origin: 0
+        %%DocumentMedia: Default {0} {0} 0 () ()
+        %%BoundingBox: 0 0 {0} {0}
+        %%LanguageLevel: 2 
+        %%Pages: 1
+        %%Page: 1 1
+        %%EndComments
+        %%BeginConstants
+        /sz {0} def
+        /sc {1} def
+        %%EndConstants
+        %%BeginFeature: *PageSize Default
+        << /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
+        %%EndFeature
 
-    private const string PS_FUNCTIONS = @"%%BeginFunctions 
-/csquare {{
-    newpath
-    0 0 moveto
-    0 1 rlineto
-    1 0 rlineto
-    0 -1 rlineto
-    closepath
-    setrgbcolor
-    fill
-}} def
-/f {{ 
-    {0} {1} {2} csquare
-    1 0 translate
-}} def
-/b {{ 
-    1 0 translate
-}} def 
-/background {{ 
-    {3} {4} {5} csquare 
-}} def
-/nl {{
-    -{6} -1 translate
-}} def
-%%EndFunctions
-%%BeginBody
-0 0 moveto
-gsave
-sz sz scale
-background
-grestore
-gsave
-sc sc scale
-0 {6} 1 sub translate
-";
+        """;
 
-    private const string PS_FOOTER = @"%%EndBody
-grestore
-showpage   
-%%EOF
-";
+    private const string PS_FUNCTIONS = """
+        %%BeginFunctions 
+        /csquare {{
+            newpath
+            0 0 moveto
+            0 1 rlineto
+            1 0 rlineto
+            0 -1 rlineto
+            closepath
+            setrgbcolor
+            fill
+        }} def
+        /f {{ 
+            {0} {1} {2} csquare
+            1 0 translate
+        }} def
+        /b {{ 
+            1 0 translate
+        }} def 
+        /background {{ 
+            {3} {4} {5} csquare 
+        }} def
+        /nl {{
+            -{6} -1 translate
+        }} def
+        %%EndFunctions
+        %%BeginBody
+        0 0 moveto
+        gsave
+        sz sz scale
+        background
+        grestore
+        gsave
+        sc sc scale
+        0 {6} 1 sub translate
+
+        """;
+
+    private const string PS_FOOTER = """
+        %%EndBody
+        grestore
+        showpage   
+        %%EOF
+
+        """;
 }
 
 /// <summary>

--- a/QRCoderTests/PostscriptQRCodeRendererTests.cs
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.cs
@@ -9,7 +9,7 @@ public class PostscriptQRCodeRendererTests
         var gen = new QRCodeGenerator();
         var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.L);
         var ps = new PostscriptQRCode(data).GetGraphic(5);
-        RemoveCreationDate(ps).ShouldMatchApproved(x => x.NoDiff());
+        ps.ShouldMatchApproved(x => x.NoDiff());
     }
 
     [Fact]
@@ -19,7 +19,7 @@ public class PostscriptQRCodeRendererTests
         var gen = new QRCodeGenerator();
         var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.L);
         var ps = new PostscriptQRCode(data).GetGraphic(5, true);
-        RemoveCreationDate(ps).ShouldMatchApproved(x => x.NoDiff());
+        ps.ShouldMatchApproved(x => x.NoDiff());
     }
 
     [Fact]
@@ -29,7 +29,7 @@ public class PostscriptQRCodeRendererTests
         var gen = new QRCodeGenerator();
         var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.L);
         var ps = new PostscriptQRCode(data).GetGraphic(new Size(33, 33));
-        RemoveCreationDate(ps).ShouldMatchApproved(x => x.NoDiff());
+        ps.ShouldMatchApproved(x => x.NoDiff());
     }
 
     [Fact]
@@ -39,7 +39,7 @@ public class PostscriptQRCodeRendererTests
         var gen = new QRCodeGenerator();
         var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.L);
         var ps = new PostscriptQRCode(data).GetGraphic(new Size(50, 50), false);
-        RemoveCreationDate(ps).ShouldMatchApproved(x => x.NoDiff());
+        ps.ShouldMatchApproved(x => x.NoDiff());
     }
 
     [Fact]
@@ -49,15 +49,6 @@ public class PostscriptQRCodeRendererTests
         var gen = new QRCodeGenerator();
         var data = gen.CreateQrCode("This is a quick test! 123#?", QRCodeGenerator.ECCLevel.L);
         var ps = new PostscriptQRCode(data).GetGraphic(5, Color.Red, Color.Blue);
-        RemoveCreationDate(ps).ShouldMatchApproved(x => x.NoDiff());
-    }
-
-    private static string RemoveCreationDate(string text)
-    {
-        // Regex pattern to match lines that start with %%CreationDate: followed by any characters until the end of the line
-        string pattern = @"%%CreationDate:.*\r?\n?";
-
-        // Use Regex.Replace to remove matching lines
-        return Regex.Replace(text, pattern, string.Empty, RegexOptions.Multiline);
+        ps.ShouldMatchApproved(x => x.NoDiff());
     }
 }


### PR DESCRIPTION
Removes the optional creation date from the created postscript instructions.  Should have no effect on output.  Makes it easier for developers that want to write tests for their code that uses QRCoder to create postscript output.  Also converted constants to raw string literals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Removed timestamp from PostScript/EPS headers for stable, reproducible output across runs and platforms.

- Refactor
  - Streamlined PostScript generation internals without altering behavior or public APIs.

- Tests
  - Updated approval tests to align with deterministic PostScript/EPS output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->