### PR TITLE
Set Deterministic property to true in build props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,6 +33,7 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <SignAssembly>false</SignAssembly>
+    <Deterministic>true</Deterministic>
 
     <!-- Enable analyzers; treat all warnings as errors; disable 'using directive is unnecessary' and XML comment warnings -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Enabled deterministic builds to produce consistent, reproducible binaries across environments and build machines. This improves reliability, traceability, and reduces discrepancies between builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->