### PR TITLE
Add LICENSE.txt to packable project items

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,6 +46,7 @@
   <!-- Include README for packable projects -->
   <ItemGroup Condition="'$(IsPackable)' == 'true'">
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <None Include="$(MSBuildThisFileDirectory)LICENSE.txt" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)nuget-icon.png" Pack="true" PackagePath="\" />
   </ItemGroup>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Included LICENSE.txt in the distributed package when packaging is enabled, alongside existing README and icon assets. No functional or API changes.
- Documentation
  - Consumers can now view the license directly within the package contents for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->