### PR TITLE
Eliminates exceptions when characters are outside ISO-8859-1 range

### DIFF
--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -995,22 +995,21 @@ public partial class QRCodeGenerator : IDisposable
         bool IsUtf8() => (encoding == EncodingMode.Byte && (forceUtf8 || !IsValidISO(plainText)));
     }
 
-    private static readonly Encoding _iso88591ExceptionFallback = Encoding.GetEncoding(28591, new EncoderExceptionFallback(), new DecoderExceptionFallback()); // ISO-8859-1
     /// <summary>
     /// Checks if the given string can be accurately represented and retrieved in ISO-8859-1 encoding.
     /// </summary>
     private static bool IsValidISO(string input)
     {
-        // No heap allocations if the string is ISO-8859-1
-        try
+        // ISO-8859-1 contains the same characters as UTF-16 for the range 0x00-0xFF.
+        //   0x00-0x7F: ASCII (0-127)
+        //   0x80-0x9F: C1 control characters (128-159)
+        //   0xA0-0xFF: Extended Latin (160-255
+        foreach (char c in input)
         {
-            _ = _iso88591ExceptionFallback.GetByteCount(input);
-            return true;
+            if (c > 0xFF)
+                return false;
         }
-        catch (EncoderFallbackException) // The exception is a heap allocation and not ideal
-        {
-            return false;
-        }
+        return true;
     }
 
     /// <summary>

--- a/QRCoder/QRCodeGenerator.cs
+++ b/QRCoder/QRCodeGenerator.cs
@@ -1003,7 +1003,7 @@ public partial class QRCodeGenerator : IDisposable
         // ISO-8859-1 contains the same characters as UTF-16 for the range 0x00-0xFF.
         //   0x00-0x7F: ASCII (0-127)
         //   0x80-0x9F: C1 control characters (128-159)
-        //   0xA0-0xFF: Extended Latin (160-255
+        //   0xA0-0xFF: Extended Latin (160-255)
         foreach (char c in input)
         {
             if (c > 0xFF)


### PR DESCRIPTION
@gfoidl  Although it only takes a few nanoseconds (billionths of a second) to run, it is 30% slower than the original code assuming all characters can be encoded.  On the other hand, it is a thousand times faster with zero allocations for a string that requires UTF-8.

| Method                   | Mean         | Error       | StdDev      | Gen0   | Allocated |
|------------------------- |-------------:|------------:|------------:|-------:|----------:|
| OriginalAsciiValid       |     6.222 ns |   0.4550 ns |   1.3415 ns |      - |         - |
| OriginalInvalidLastChar  | 9,625.746 ns | 190.4809 ns | 247.6790 ns | 0.1373 |     888 B |
| OptimizedAsciiValid      |     8.275 ns |   0.1907 ns |   0.2119 ns |      - |         - |
| OptimizedInvalidLastChar |    11.375 ns |   0.2461 ns |   0.2302 ns |      - |         - |

I could not find a more optimized approach.