### PR TITLE
Add benchmark for multi-mode QR code generation

### DIFF
--- a/QRCoderBenchmarks/QRCodeGeneratorBenchmark.cs
+++ b/QRCoderBenchmarks/QRCodeGeneratorBenchmark.cs
@@ -14,6 +14,14 @@ public class QRCodeGeneratorBenchmark
     }
 
     [Benchmark]
+    public void CreateQRCodeMultiMode()
+    {
+        var payload = new QRCoder.PayloadGenerator.Url("HTTPS://GITHUB.COM/Shane32/QRCoder/blob/F89AA90081F369983A9BA114E49CC6EBF0B2A7B1/QRCoder/Framework4.0Methods/Stream4Methods.cs");
+        var qrGenerator = new QRCoder.QRCodeGenerator();
+        _ = qrGenerator.CreateQrCode(payload, QRCoder.QRCodeGenerator.ECCLevel.L);
+    }
+
+    [Benchmark]
     public void CreateQRCodeLong()
     {
         var payload = new QRCoder.PayloadGenerator.Url("https://github.com/Shane32/QRCoder/blob/f89aa90081f369983a9ba114e49cc6ebf0b2a7b1/QRCoder/Framework4.0Methods/Stream4Methods.cs");


### PR DESCRIPTION
Introduce a benchmark for generating QR codes in multiple modes to evaluate performance.  Note that the url is functional, leading to the same destination as the 'Long' sample -- however, the entire url cannot be uppercase since filenames are case sensitive.  Multi mode support does not yet exist, but this can be used to test speed improvements by common changes to encoded URLs once it is added.