### PR TITLE
Fix condition for ISO-8859-1 encoding selection in GetTargetEncoding method

### DIFF
--- a/QRCoder/QRCodeGenerator/ByteDataSegment.cs
+++ b/QRCoder/QRCodeGenerator/ByteDataSegment.cs
@@ -122,7 +122,7 @@ public partial class QRCodeGenerator
         Encoding targetEncoding;
 
         // Check if the text is valid ISO-8859-1 and UTF-8 is not forced, then encode using ISO-8859-1.
-        if (IsValidISO(plainText) && !forceUtf8)
+        if (eciMode == EciMode.Default && !forceUtf8 && IsValidISO(plainText))
         {
             targetEncoding = _iso8859_1;
             includeUtf8BOM = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * QR code encoding now correctly respects the selected ECI mode.
  * ISO-8859-1 fallback is applied only when ECI mode is set to Default, preventing unintended overrides with non-default modes.
  * Ensures consistent behavior across UTF-8, BOM, and other encodings when a specific ECI mode is chosen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->