### PR TITLE
Fix EPS protocol violations in PostscriptQRCode: remove showpage and setpagedevice from EPS output

### DIFF
--- a/QRCoder/PostscriptQRCode.cs
+++ b/QRCoder/PostscriptQRCode.cs
@@ -226,6 +226,7 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
     // not leak the current point into the surrounding document.
     private const string EPS_FUNCTIONS = """
         %%BeginProlog
+        5 dict begin
         /csquare {{
             newpath
             0 0 moveto
@@ -254,7 +255,6 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         /sz {7} def
         /sc {8} def
         %%EndSetup
-        %%BeginBody
         gsave
         0 0 moveto
         sz sz scale
@@ -276,9 +276,10 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         """;
 
     // EPS footer — showpage is forbidden in EPS files (Adobe Technical Note #5002).
+    // 'end' pops the private dictionary pushed in %%BeginProlog to avoid polluting the host dict stack.
     private const string EPS_FOOTER = """
-        %%EndBody
         grestore
+        end
         %%EOF
 
         """;

--- a/QRCoder/PostscriptQRCode.cs
+++ b/QRCoder/PostscriptQRCode.cs
@@ -176,7 +176,6 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         %%Creator: QRCoder.NET
         %%Title: QRCode
         %%DocumentData: Clean7Bit
-        %%Origin: 0
         %%BoundingBox: 0 0 {0} {0}
         %%LanguageLevel: 2
         %%EndComments

--- a/QRCoder/PostscriptQRCode.cs
+++ b/QRCoder/PostscriptQRCode.cs
@@ -102,9 +102,10 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         var pointsPerModule = (double)Math.Min(viewBox.Width, viewBox.Height) / (double)drawableModulesCount;
 
         var header = epsFormat ? EPS_HEADER : PS_HEADER;
+        var functions = epsFormat ? EPS_FUNCTIONS : PS_FUNCTIONS;
         var footer = epsFormat ? EPS_FOOTER : PS_FOOTER;
 
-        var estimatedCapacity = header.Length + PS_FUNCTIONS.Length + footer.Length +
+        var estimatedCapacity = header.Length + functions.Length + footer.Length +
             (drawableModulesCount * drawableModulesCount * 2) + // modules (either "f " or "b ")
             drawableModulesCount * 3 + // newlines ("nl\n")
             200; // embedded numbers
@@ -113,10 +114,11 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         sb.AppendFormat(CultureInfo.InvariantCulture, header, [
             CleanSvgVal(viewBox.Width), CleanSvgVal(pointsPerModule)
         ]);
-        sb.AppendFormat(CultureInfo.InvariantCulture, PS_FUNCTIONS, [
+        sb.AppendFormat(CultureInfo.InvariantCulture, functions, [
             CleanSvgVal(darkColor.R /255.0), CleanSvgVal(darkColor.G /255.0), CleanSvgVal(darkColor.B /255.0),
             CleanSvgVal(lightColor.R /255.0), CleanSvgVal(lightColor.G /255.0), CleanSvgVal(lightColor.B /255.0),
-            drawableModulesCount
+            drawableModulesCount,
+            CleanSvgVal(viewBox.Width), CleanSvgVal(pointsPerModule)
         ]);
 
         for (int xi = offset; xi < offset + drawableModulesCount; xi++)
@@ -168,6 +170,7 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
 
     // EPS header — omits %%DocumentMedia, %%Pages, %%Page, and setpagedevice, all of which are
     // forbidden or inappropriate in Encapsulated PostScript (Adobe Technical Note #5002).
+    // Constants (sz, sc) and procedure definitions are emitted in EPS_FUNCTIONS below.
     private const string EPS_HEADER = """
         %!PS-Adobe-3.0 EPSF-3.0
         %%Creator: QRCoder.NET
@@ -177,10 +180,6 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         %%BoundingBox: 0 0 {0} {0}
         %%LanguageLevel: 2
         %%EndComments
-        %%BeginConstants
-        /sz {0} def
-        /sc {1} def
-        %%EndConstants
 
         """;
 
@@ -213,6 +212,51 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         %%BeginBody
         0 0 moveto
         gsave
+        sz sz scale
+        background
+        grestore
+        gsave
+        sc sc scale
+        0 {6} 1 sub translate
+
+        """;
+
+    // EPS variant: uses standard DSC %%BeginProlog/%%EndProlog for procedure definitions,
+    // %%BeginSetup/%%EndSetup for constants, and moves 0 0 moveto inside gsave so it does
+    // not leak the current point into the surrounding document.
+    private const string EPS_FUNCTIONS = """
+        %%BeginProlog
+        /csquare {{
+            newpath
+            0 0 moveto
+            0 1 rlineto
+            1 0 rlineto
+            0 -1 rlineto
+            closepath
+            setrgbcolor
+            fill
+        }} def
+        /f {{
+            {0} {1} {2} csquare
+            1 0 translate
+        }} def
+        /b {{
+            1 0 translate
+        }} def
+        /background {{
+            {3} {4} {5} csquare
+        }} def
+        /nl {{
+            -{6} -1 translate
+        }} def
+        %%EndProlog
+        %%BeginSetup
+        /sz {7} def
+        /sc {8} def
+        %%EndSetup
+        %%BeginBody
+        gsave
+        0 0 moveto
         sz sz scale
         background
         grestore

--- a/QRCoder/PostscriptQRCode.cs
+++ b/QRCoder/PostscriptQRCode.cs
@@ -101,15 +101,17 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
         var drawableModulesCount = QrCodeData.ModuleMatrix.Count - (drawQuietZones ? 0 : offset * 2);
         var pointsPerModule = (double)Math.Min(viewBox.Width, viewBox.Height) / (double)drawableModulesCount;
 
-        var estimatedCapacity = PS_HEADER.Length + PS_FUNCTIONS.Length + PS_FOOTER.Length +
+        var header = epsFormat ? EPS_HEADER : PS_HEADER;
+        var footer = epsFormat ? EPS_FOOTER : PS_FOOTER;
+
+        var estimatedCapacity = header.Length + PS_FUNCTIONS.Length + footer.Length +
             (drawableModulesCount * drawableModulesCount * 2) + // modules (either "f " or "b ")
             drawableModulesCount * 3 + // newlines ("nl\n")
             200; // embedded numbers
         var sb = new StringBuilder(estimatedCapacity);
 
-        sb.AppendFormat(CultureInfo.InvariantCulture, PS_HEADER, [
-            CleanSvgVal(viewBox.Width), CleanSvgVal(pointsPerModule),
-            epsFormat ? "EPSF-3.0" : string.Empty
+        sb.AppendFormat(CultureInfo.InvariantCulture, header, [
+            CleanSvgVal(viewBox.Width), CleanSvgVal(pointsPerModule)
         ]);
         sb.AppendFormat(CultureInfo.InvariantCulture, PS_FUNCTIONS, [
             CleanSvgVal(darkColor.R /255.0), CleanSvgVal(darkColor.G /255.0), CleanSvgVal(darkColor.B /255.0),
@@ -127,7 +129,7 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
             }
         }
         sb.Append('\n');
-        sb.Append(PS_FOOTER);
+        sb.Append(footer);
         return sb.ToString();
     }
 
@@ -140,15 +142,17 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
 
     // Note: line terminations here will encode differently based on which platform QRCoder was compiled on (CRLF vs LF);
     // however, PostScript interpreters should handle both equally well.
+
+    // Standard PostScript header — includes media/page setup and setpagedevice (valid for standalone PS documents).
     private const string PS_HEADER = """
-        %!PS-Adobe-3.0 {2}
+        %!PS-Adobe-3.0
         %%Creator: QRCoder.NET
         %%Title: QRCode
         %%DocumentData: Clean7Bit
         %%Origin: 0
         %%DocumentMedia: Default {0} {0} 0 () ()
         %%BoundingBox: 0 0 {0} {0}
-        %%LanguageLevel: 2 
+        %%LanguageLevel: 2
         %%Pages: 1
         %%Page: 1 1
         %%EndComments
@@ -162,8 +166,26 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
 
         """;
 
+    // EPS header — omits %%DocumentMedia, %%Pages, %%Page, and setpagedevice, all of which are
+    // forbidden or inappropriate in Encapsulated PostScript (Adobe Technical Note #5002).
+    private const string EPS_HEADER = """
+        %!PS-Adobe-3.0 EPSF-3.0
+        %%Creator: QRCoder.NET
+        %%Title: QRCode
+        %%DocumentData: Clean7Bit
+        %%Origin: 0
+        %%BoundingBox: 0 0 {0} {0}
+        %%LanguageLevel: 2
+        %%EndComments
+        %%BeginConstants
+        /sz {0} def
+        /sc {1} def
+        %%EndConstants
+
+        """;
+
     private const string PS_FUNCTIONS = """
-        %%BeginFunctions 
+        %%BeginFunctions
         /csquare {{
             newpath
             0 0 moveto
@@ -174,15 +196,15 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
             setrgbcolor
             fill
         }} def
-        /f {{ 
+        /f {{
             {0} {1} {2} csquare
             1 0 translate
         }} def
-        /b {{ 
+        /b {{
             1 0 translate
-        }} def 
-        /background {{ 
-            {3} {4} {5} csquare 
+        }} def
+        /background {{
+            {3} {4} {5} csquare
         }} def
         /nl {{
             -{6} -1 translate
@@ -200,10 +222,19 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
 
         """;
 
+    // Standard PostScript footer — showpage is required for standalone PS documents.
     private const string PS_FOOTER = """
         %%EndBody
         grestore
-        showpage   
+        showpage
+        %%EOF
+
+        """;
+
+    // EPS footer — showpage is forbidden in EPS files (Adobe Technical Note #5002).
+    private const string EPS_FOOTER = """
+        %%EndBody
+        grestore
         %%EOF
 
         """;

--- a/QRCoder/PostscriptQRCode.cs
+++ b/QRCoder/PostscriptQRCode.cs
@@ -225,7 +225,7 @@ public class PostscriptQRCode : AbstractQRCode, IDisposable
     // not leak the current point into the surrounding document.
     private const string EPS_FUNCTIONS = """
         %%BeginProlog
-        5 dict begin
+        7 dict begin
         /csquare {{
             newpath
             0 0 moveto

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_colors.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_colors.approved.txt
@@ -1,11 +1,11 @@
-%!PS-Adobe-3.0 
+%!PS-Adobe-3.0
 %%Creator: QRCoder.NET
 %%Title: QRCode
 %%DocumentData: Clean7Bit
 %%Origin: 0
 %%DocumentMedia: Default 165 165 0 () ()
 %%BoundingBox: 0 0 165 165
-%%LanguageLevel: 2 
+%%LanguageLevel: 2
 %%Pages: 1
 %%Page: 1 1
 %%EndComments
@@ -16,7 +16,7 @@
 %%BeginFeature: *PageSize Default
 << /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
 %%EndFeature
-%%BeginFunctions 
+%%BeginFunctions
 /csquare {
     newpath
     0 0 moveto
@@ -27,15 +27,15 @@
     setrgbcolor
     fill
 } def
-/f { 
+/f {
     1 0 0 csquare
     1 0 translate
 } def
-/b { 
+/b {
     1 0 translate
-} def 
-/background { 
-    0 0 1 csquare 
+} def
+/background {
+    0 0 1 csquare
 } def
 /nl {
     -33 -1 translate
@@ -85,5 +85,5 @@ b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b 
 %%EndBody
 grestore
-showpage   
+showpage
 %%EOF

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
@@ -3,20 +3,14 @@
 %%Title: QRCode
 %%DocumentData: Clean7Bit
 %%Origin: 0
-%%DocumentMedia: Default 165 165 0 () ()
 %%BoundingBox: 0 0 165 165
-%%LanguageLevel: 2 
-%%Pages: 1
-%%Page: 1 1
+%%LanguageLevel: 2
 %%EndComments
 %%BeginConstants
 /sz 165 def
 /sc 5 def
 %%EndConstants
-%%BeginFeature: *PageSize Default
-<< /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
-%%EndFeature
-%%BeginFunctions 
+%%BeginFunctions
 /csquare {
     newpath
     0 0 moveto
@@ -27,15 +21,15 @@
     setrgbcolor
     fill
 } def
-/f { 
+/f {
     0 0 0 csquare
     1 0 translate
 } def
-/b { 
+/b {
     1 0 translate
-} def 
-/background { 
-    1 1 1 csquare 
+} def
+/background {
+    1 1 1 csquare
 } def
 /nl {
     -33 -1 translate
@@ -85,5 +79,4 @@ b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b 
 %%EndBody
 grestore
-showpage   
 %%EOF

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
@@ -2,7 +2,6 @@
 %%Creator: QRCoder.NET
 %%Title: QRCode
 %%DocumentData: Clean7Bit
-%%Origin: 0
 %%BoundingBox: 0 0 165 165
 %%LanguageLevel: 2
 %%EndComments

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
@@ -7,6 +7,7 @@
 %%LanguageLevel: 2
 %%EndComments
 %%BeginProlog
+5 dict begin
 /csquare {
     newpath
     0 0 moveto
@@ -35,7 +36,6 @@
 /sz 165 def
 /sc 5 def
 %%EndSetup
-%%BeginBody
 gsave
 0 0 moveto
 sz sz scale
@@ -77,6 +77,6 @@ b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b 
-%%EndBody
 grestore
+end
 %%EOF

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
@@ -6,7 +6,7 @@
 %%LanguageLevel: 2
 %%EndComments
 %%BeginProlog
-5 dict begin
+7 dict begin
 /csquare {
     newpath
     0 0 moveto

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_eps.approved.txt
@@ -6,11 +6,7 @@
 %%BoundingBox: 0 0 165 165
 %%LanguageLevel: 2
 %%EndComments
-%%BeginConstants
-/sz 165 def
-/sc 5 def
-%%EndConstants
-%%BeginFunctions
+%%BeginProlog
 /csquare {
     newpath
     0 0 moveto
@@ -34,10 +30,14 @@
 /nl {
     -33 -1 translate
 } def
-%%EndFunctions
+%%EndProlog
+%%BeginSetup
+/sz 165 def
+/sc 5 def
+%%EndSetup
 %%BeginBody
-0 0 moveto
 gsave
+0 0 moveto
 sz sz scale
 background
 grestore

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_simple.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_simple.approved.txt
@@ -1,11 +1,11 @@
-%!PS-Adobe-3.0 
+%!PS-Adobe-3.0
 %%Creator: QRCoder.NET
 %%Title: QRCode
 %%DocumentData: Clean7Bit
 %%Origin: 0
 %%DocumentMedia: Default 165 165 0 () ()
 %%BoundingBox: 0 0 165 165
-%%LanguageLevel: 2 
+%%LanguageLevel: 2
 %%Pages: 1
 %%Page: 1 1
 %%EndComments
@@ -16,7 +16,7 @@
 %%BeginFeature: *PageSize Default
 << /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
 %%EndFeature
-%%BeginFunctions 
+%%BeginFunctions
 /csquare {
     newpath
     0 0 moveto
@@ -27,15 +27,15 @@
     setrgbcolor
     fill
 } def
-/f { 
+/f {
     0 0 0 csquare
     1 0 translate
 } def
-/b { 
+/b {
     1 0 translate
-} def 
-/background { 
-    1 1 1 csquare 
+} def
+/background {
+    1 1 1 csquare
 } def
 /nl {
     -33 -1 translate
@@ -85,5 +85,5 @@ b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b 
 %%EndBody
 grestore
-showpage   
+showpage
 %%EOF

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_size.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_size.approved.txt
@@ -1,11 +1,11 @@
-%!PS-Adobe-3.0 
+%!PS-Adobe-3.0
 %%Creator: QRCoder.NET
 %%Title: QRCode
 %%DocumentData: Clean7Bit
 %%Origin: 0
 %%DocumentMedia: Default 33 33 0 () ()
 %%BoundingBox: 0 0 33 33
-%%LanguageLevel: 2 
+%%LanguageLevel: 2
 %%Pages: 1
 %%Page: 1 1
 %%EndComments
@@ -16,7 +16,7 @@
 %%BeginFeature: *PageSize Default
 << /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
 %%EndFeature
-%%BeginFunctions 
+%%BeginFunctions
 /csquare {
     newpath
     0 0 moveto
@@ -27,15 +27,15 @@
     setrgbcolor
     fill
 } def
-/f { 
+/f {
     0 0 0 csquare
     1 0 translate
 } def
-/b { 
+/b {
     1 0 translate
-} def 
-/background { 
-    1 1 1 csquare 
+} def
+/background {
+    1 1 1 csquare
 } def
 /nl {
     -33 -1 translate
@@ -85,5 +85,5 @@ b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b 
 %%EndBody
 grestore
-showpage   
+showpage
 %%EOF

--- a/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_size_no_quiet_zones.approved.txt
+++ b/QRCoderTests/PostscriptQRCodeRendererTests.can_render_postscript_qrcode_size_no_quiet_zones.approved.txt
@@ -1,11 +1,11 @@
-%!PS-Adobe-3.0 
+%!PS-Adobe-3.0
 %%Creator: QRCoder.NET
 %%Title: QRCode
 %%DocumentData: Clean7Bit
 %%Origin: 0
 %%DocumentMedia: Default 50 50 0 () ()
 %%BoundingBox: 0 0 50 50
-%%LanguageLevel: 2 
+%%LanguageLevel: 2
 %%Pages: 1
 %%Page: 1 1
 %%EndComments
@@ -16,7 +16,7 @@
 %%BeginFeature: *PageSize Default
 << /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
 %%EndFeature
-%%BeginFunctions 
+%%BeginFunctions
 /csquare {
     newpath
     0 0 moveto
@@ -27,15 +27,15 @@
     setrgbcolor
     fill
 } def
-/f { 
+/f {
     0 0 0 csquare
     1 0 translate
 } def
-/b { 
+/b {
     1 0 translate
-} def 
-/background { 
-    1 1 1 csquare 
+} def
+/background {
+    1 1 1 csquare
 } def
 /nl {
     -25 -1 translate
@@ -77,5 +77,5 @@ f b b b b b f b f f f f b f f b b f b b f f f b b nl
 f f f f f f f b f b b b b f b b b f f b b b f f f 
 %%EndBody
 grestore
-showpage   
+showpage
 %%EOF

--- a/QRCoderTests/TransposeVerificationTests.postscript_renderer.approved.ps
+++ b/QRCoderTests/TransposeVerificationTests.postscript_renderer.approved.ps
@@ -1,11 +1,11 @@
-%!PS-Adobe-3.0 
+%!PS-Adobe-3.0
 %%Creator: QRCoder.NET
 %%Title: QRCode
 %%DocumentData: Clean7Bit
 %%Origin: 0
 %%DocumentMedia: Default 290 290 0 () ()
 %%BoundingBox: 0 0 290 290
-%%LanguageLevel: 2 
+%%LanguageLevel: 2
 %%Pages: 1
 %%Page: 1 1
 %%EndComments
@@ -16,7 +16,7 @@
 %%BeginFeature: *PageSize Default
 << /PageSize [ sz sz ] /ImagingBBox null >> setpagedevice
 %%EndFeature
-%%BeginFunctions 
+%%BeginFunctions
 /csquare {
     newpath
     0 0 moveto
@@ -27,15 +27,15 @@
     setrgbcolor
     fill
 } def
-/f { 
+/f {
     0 0 0 csquare
     1 0 translate
 } def
-/b { 
+/b {
     1 0 translate
-} def 
-/background { 
-    1 1 1 csquare 
+} def
+/background {
+    1 1 1 csquare
 } def
 /nl {
     -29 -1 translate
@@ -81,5 +81,5 @@ b b b b b b b b b b b b b b b b b b b b b b b b b b b b b nl
 b b b b b b b b b b b b b b b b b b b b b b b b b b b b b 
 %%EndBody
 grestore
-showpage   
+showpage
 %%EOF


### PR DESCRIPTION
## Fix EPS protocol violations in `PostscriptQRCode`

### Problem

When `epsFormat = true`, the generated output violated the EPS specification (Adobe Technical Note #5002) in multiple ways. Previously only the magic comment on line 1 changed between PS and EPS modes; all other content — including forbidden operators and non-standard structure — was shared.

### Changes

#### Hard violations fixed

| Issue | Fix |
|---|---|
| **`showpage` in EPS** — forbidden; causes host document to eject a page when the EPS is placed | Removed from EPS output; retained in PS output |
| **`setpagedevice` in EPS** — forbidden device-control operator; EPS must be device-independent | Removed from EPS output (entire `%%BeginFeature`/`%%EndFeature` block) |
| **`0 0 moveto` outside `gsave`** — leaks current-point state into the surrounding document | Moved inside `gsave` in EPS output |
| **Procedures defined in host dictionary** — risks name collisions and `dictfull` errors when embedded | EPS prolog uses `7 dict begin` / `end` to isolate all 7 definitions (`csquare`, `f`, `b`, `background`, `nl`, `sz`, `sc`) in a private dictionary |

#### Inappropriate DSC comments removed from EPS

| Removed | Reason |
|---|---|
| `%%DocumentMedia` | Describes physical paper media; meaningless in an embedded graphic |
| `%%Pages` / `%%Page` | Multi-page document markers; EPS describes a single graphic |
| `%%Origin` | Device-specific physical origin; not applicable to EPS |

#### Non-standard DSC structure replaced in EPS

| Before | After |
|---|---|
| `%%BeginConstants` / `%%EndConstants` | Constants moved into `%%BeginSetup` / `%%EndSetup` |
| `%%BeginFunctions` / `%%EndFunctions` | `%%BeginProlog` / `%%EndProlog` (standard DSC) |
| `%%BeginBody` / `%%EndBody` | Removed (non-standard; not needed in EPS) |

#### Minor PS fixes

- Removed trailing spaces from `%%LanguageLevel: 2`, `%%BeginFunctions`, and `showpage` in the PS templates
- Removed trailing space from `%!PS-Adobe-3.0` magic comment

### Implementation

A separate `EPS_HEADER`, `EPS_FUNCTIONS`, and `EPS_FOOTER` constant set was introduced. The PS path (`PS_HEADER`, `PS_FUNCTIONS`, `PS_FOOTER`) is unchanged in behaviour. `GetGraphic()` selects the correct set based on `epsFormat`.

The resulting EPS structure is:

```postscript
%!PS-Adobe-3.0 EPSF-3.0
%%Creator: QRCoder.NET
%%Title: QRCode
%%DocumentData: Clean7Bit
%%BoundingBox: 0 0 <w> <h>
%%LanguageLevel: 2
%%EndComments
%%BeginProlog
7 dict begin
/csquare { ... } def
/f { ... } def
/b { ... } def
/background { ... } def
/nl { ... } def
%%EndProlog
%%BeginSetup
/sz <w> def
/sc <ppm> def
%%EndSetup
gsave
0 0 moveto
sz sz scale
background
grestore
gsave
sc sc scale
0 <n> 1 sub translate
<module data>
grestore
end
%%EOF
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced EPS (Encapsulated PostScript) format support with proper DSC compliance and dedicated template handling.

* **Bug Fixes**
  * Improved PostScript output formatting and standards compliance; removed extraneous whitespace from generated documents.
  * Fixed PostScript document structure for better compatibility with PostScript interpreters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->