### PR TITLE
Minor performance improvement in BitmapByteQRCode + clarify padding calculation

### DIFF
--- a/QRCoder/BitmapByteQRCode.cs
+++ b/QRCoder/BitmapByteQRCode.cs
@@ -1,3 +1,8 @@
+#if NETCOREAPP2_1_OR_GREATER
+using System.Buffers.Binary;
+#endif
+using System.Diagnostics;
+
 using static QRCoder.QRCodeGenerator;
 
 namespace QRCoder;
@@ -67,8 +72,10 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
             moduleLight[i + 2] = lightColorRgb[0];
         }
 
+        // The size of each row must be rounded up to a multiple of 4 bytes by padding.
         // Pre-calculate padding bytes
-        var paddingLen = sideLength % 4;
+        var paddingLen = -sideLength & 3;
+        Debug.Assert(paddingLen >= 0 && paddingLen < 4 && (sideLength + paddingLen) % 4 == 0);
 
         // Calculate filesize (header + pixel data + padding)
         var fileSize = 54 + (3 * (sideLength * sideLength)) + (sideLength * paddingLen);
@@ -142,6 +149,9 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
     /// <param name="destinationArray">Destination byte array that receives the bytes</param>
     private static void CopyIntAs4ByteToArray(int inp, int destinationIndex, byte[] destinationArray)
     {
+#if NETCOREAPP2_1_OR_GREATER
+        BinaryPrimitives.WriteInt32LittleEndian(destinationArray.AsSpan(destinationIndex), inp);
+#else
         unchecked
         {
             destinationArray[destinationIndex + 3] = (byte)(inp >> 24);
@@ -149,6 +159,7 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
             destinationArray[destinationIndex + 1] = (byte)(inp >> 8);
             destinationArray[destinationIndex + 0] = (byte)(inp);
         }
+#endif
     }
 }
 

--- a/QRCoder/BitmapByteQRCode.cs
+++ b/QRCoder/BitmapByteQRCode.cs
@@ -74,11 +74,12 @@ public class BitmapByteQRCode : AbstractQRCode, IDisposable
 
         // The size of each row must be rounded up to a multiple of 4 bytes by padding.
         // Pre-calculate padding bytes
-        var paddingLen = -sideLength & 3;
-        Debug.Assert(paddingLen >= 0 && paddingLen < 4 && (sideLength + paddingLen) % 4 == 0);
+        var rowByteLength = sideLength * 3;
+        var paddingLen = -rowByteLength & 3;
+        Debug.Assert(paddingLen >= 0 && paddingLen < 4 && (rowByteLength + paddingLen) % 4 == 0);
 
         // Calculate filesize (header + pixel data + padding)
-        var fileSize = 54 + (3 * (sideLength * sideLength)) + (sideLength * paddingLen);
+        var fileSize = 54 + (rowByteLength + paddingLen) * sideLength;
 
         // Bitmap container
         byte[] bmp = new byte[fileSize];


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**:

* [x] Fixes a bug in BMP padding calculation when `pixelsPerModule` is odd.
* [x] Minor optimization using [BinaryPrimitives.WriteInt32LittleEndian(Span<Byte>, Int32)](https://learn.microsoft.com/en-us/dotnet/api/system.buffers.binary.binaryprimitives.writeint32littleendian) on modern .NET

## Closing issues
Fixes #697 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved QR bitmap generation across supported platforms for more consistent output.
  * Corrected bitmap row padding calculations to ensure proper byte alignment.
  * Enhanced binary integer writing on newer .NET Core versions to reliably produce the expected byte order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->